### PR TITLE
Don't prepend relative URLs with InputFolder in Less files

### DIFF
--- a/Wyam.Modules.Less/Less.cs
+++ b/Wyam.Modules.Less/Less.cs
@@ -19,7 +19,6 @@ namespace Wyam.Modules.Less
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
         {
             DotlessConfiguration config = DotlessConfiguration.GetDefault();
-            config.RootPath = context.InputFolder;
             config.Logger = typeof (LessLogger);
 
             EngineFactory engineFactory = new EngineFactory(config);


### PR DESCRIPTION
When using [these files](https://gist.github.com/Rohansi/102e509337ac73da70b9), the output CSS is prepended with InputFolder but it shouldn't be.

Reproduced in 0.7.0-beta, tested my changes and the URL stops being modified and imports still work. 
