### PR TITLE
Added Feature to AutoLink Module to only Match howl Words

### DIFF
--- a/Wyam.Modules.Html.Tests/AutoLinkFixture.cs
+++ b/Wyam.Modules.Html.Tests/AutoLinkFixture.cs
@@ -520,5 +520,51 @@ namespace Wyam.Modules.Html.Tests
             document.Received().Clone(output);
             stream.Dispose();
         }
+
+        [Test]
+        public void IgnoreSubstringIfSearchingForHowlWords()
+        {
+            // Given
+            string input = @"<html>
+                    <head>
+                        <title>Foobar</title>
+                    </head>
+                    <body>
+                        <h1>Title</h1>
+                        <p>This is some <i>Foo</i> text Foobaz</p>
+                    </body>
+                </html>";
+            string output = @"<html><head>
+                        <title>Foobar</title>
+                    </head>
+                    <body>
+                        <h1>Title</h1>
+                        <p>This is some <i><a href=""http://www.google.com"">Foo</a></i> text Foobaz</p>
+                    
+                </body></html>".Replace("\r\n", "\n");
+            IDocument document = Substitute.For<IDocument>();
+            MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+            document.GetStream().Returns(stream);
+            IExecutionContext context = Substitute.For<IExecutionContext>();
+            Dictionary<string, string> convertedLinks;
+            context.TryConvert(new object(), out convertedLinks)
+                .ReturnsForAnyArgs(x =>
+                {
+                    x[1] = x[0];
+                    return true;
+                });
+            AutoLink autoLink = new AutoLink(new Dictionary<string, string>()
+            {
+                { "Foo", "http://www.google.com" },
+            }).WithMatchOnlyHowlWord();
+
+            // When
+            autoLink.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+            // Then
+            document.Received(1).Clone(Arg.Any<string>());
+            document.Received().Clone(output);
+            stream.Dispose();
+        }
     }
 }

--- a/Wyam.Modules.Html.Tests/AutoLinkFixture.cs
+++ b/Wyam.Modules.Html.Tests/AutoLinkFixture.cs
@@ -522,7 +522,7 @@ namespace Wyam.Modules.Html.Tests
         }
 
         [Test]
-        public void IgnoreSubstringIfSearchingForHowlWords()
+        public void IgnoreSubstringIfSearchingForWholeWords()
         {
             // Given
             string input = @"<html>
@@ -556,7 +556,7 @@ namespace Wyam.Modules.Html.Tests
             AutoLink autoLink = new AutoLink(new Dictionary<string, string>()
             {
                 { "Foo", "http://www.google.com" },
-            }).WithMatchOnlyHowlWord();
+            }).WithMatchOnlyWholeWord();
 
             // When
             autoLink.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list

--- a/Wyam.Modules.Html.Tests/Wyam.Modules.Html.Tests.csproj
+++ b/Wyam.Modules.Html.Tests/Wyam.Modules.Html.Tests.csproj
@@ -35,9 +35,25 @@
       <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,7 +71,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wyam.Common\Wyam.Common.csproj">

--- a/Wyam.Modules.Html.Tests/packages.config
+++ b/Wyam.Modules.Html.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net46" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net46" />
 </packages>

--- a/Wyam.Modules.Html/AutoLink.cs
+++ b/Wyam.Modules.Html/AutoLink.cs
@@ -23,6 +23,7 @@ namespace Wyam.Modules.Html
         private readonly ConfigHelper<IDictionary<string, string>> _links;
         private readonly IDictionary<string, string> _extraLinks = new Dictionary<string, string>();
         private string _querySelector = "p";
+        private bool _matchOnlyHowlWord =false;
 
 
         public AutoLink()
@@ -54,6 +55,12 @@ namespace Wyam.Modules.Html
         public AutoLink WithLink(string text, string link)
         {
             _extraLinks[text] = link;
+            return this;
+        }
+
+        public AutoLink WithMatchOnlyHowlWord()
+        {
+            _matchOnlyHowlWord = true;
             return this;
         }
 
@@ -138,7 +145,7 @@ namespace Wyam.Modules.Html
                     }
                 }
 
-                if (lastNode.IsRoot)
+                if (lastNode.IsRoot && CheckAdditonalConditions(s, matchIdx, i-1))
                 {
                     // Complete match
                     string key = new string(lastNode.Cumulative.ToArray());
@@ -167,6 +174,15 @@ namespace Wyam.Modules.Html
             return builder.ToString();
         }
 
+        private bool CheckAdditonalConditions(string stringToCheck, int matchStartIndex, int matchEndIndex)
+        {
+            return !_matchOnlyHowlWord || (
+                (matchEndIndex >= stringToCheck.Length -1|| !char.IsLetterOrDigit(stringToCheck[matchEndIndex+1])) 
+                && (matchStartIndex - 1 < 0 || !char.IsLetterOrDigit(stringToCheck[matchStartIndex - 1]))
+                );
+        }
+
+  
         private class Trie<T> where T : IComparable<T>
         {
             public Node Root { get; }

--- a/Wyam.Modules.Html/AutoLink.cs
+++ b/Wyam.Modules.Html/AutoLink.cs
@@ -23,7 +23,7 @@ namespace Wyam.Modules.Html
         private readonly ConfigHelper<IDictionary<string, string>> _links;
         private readonly IDictionary<string, string> _extraLinks = new Dictionary<string, string>();
         private string _querySelector = "p";
-        private bool _matchOnlyHowlWord =false;
+        private bool _matchOnlyWholeWord =false;
 
 
         public AutoLink()
@@ -58,9 +58,9 @@ namespace Wyam.Modules.Html
             return this;
         }
 
-        public AutoLink WithMatchOnlyHowlWord()
+        public AutoLink WithMatchOnlyWholeWord()
         {
-            _matchOnlyHowlWord = true;
+            _matchOnlyWholeWord = true;
             return this;
         }
 
@@ -176,7 +176,7 @@ namespace Wyam.Modules.Html
 
         private bool CheckAdditonalConditions(string stringToCheck, int matchStartIndex, int matchEndIndex)
         {
-            return !_matchOnlyHowlWord || (
+            return !_matchOnlyWholeWord || (
                 (matchEndIndex >= stringToCheck.Length -1|| !char.IsLetterOrDigit(stringToCheck[matchEndIndex+1])) 
                 && (matchStartIndex - 1 < 0 || !char.IsLetterOrDigit(stringToCheck[matchStartIndex - 1]))
                 );


### PR DESCRIPTION
I had problems with the AutoLink Module, it created links in the middle of a word.

So I added WithMatchOnlyHowlWord() Method and checked before adding the new link if the next char and the previous char is a letter or digit. If not the link will be added, else the node is not regarded as Root.
