### PR TITLE
Added new Modules and Information to Git Modules

### DIFF
--- a/Wyam.Modules.Git/CommitInformation.cs
+++ b/Wyam.Modules.Git/CommitInformation.cs
@@ -9,19 +9,25 @@ namespace Wyam.Modules.Git
 {
     public class CommitInformation
     {
+        private string Sha { get; }
+        private IEnumerable<string> Parents { get; }
         public Author Author { get; }
         public Author Committer { get; }
         public string Message { get; }
         public ChangeKind Status { get; }
         public string Path { get; private set; }
 
-        public CommitInformation(ChangeKind status, Author author, Author committer, string message, string path)
+
+
+        public CommitInformation(ChangeKind status, Author author, Author committer, string message, string path, string sha, IEnumerable<string> parents) 
         {
             this.Status = status;
             this.Author = author;
             this.Committer = committer;
             this.Message = message;
             this.Path = path;
+            this.Sha = sha;
+            this.Parents = parents.ToArray();
         }
     }
 }

--- a/Wyam.Modules.Git/CommitInformation.cs
+++ b/Wyam.Modules.Git/CommitInformation.cs
@@ -9,8 +9,8 @@ namespace Wyam.Modules.Git
 {
     public class CommitInformation
     {
-        private string Sha { get; }
-        private IEnumerable<string> Parents { get; }
+        public string Sha { get; }
+        public IEnumerable<string> Parents { get; }
         public Author Author { get; }
         public Author Committer { get; }
         public string Message { get; }
@@ -19,7 +19,7 @@ namespace Wyam.Modules.Git
 
 
 
-        public CommitInformation(ChangeKind status, Author author, Author committer, string message, string path, string sha, IEnumerable<string> parents) 
+        public CommitInformation(ChangeKind status, Author author, Author committer, string message, string path, string sha, IEnumerable<string> parents)
         {
             this.Status = status;
             this.Author = author;

--- a/Wyam.Modules.Git/GitBase.cs
+++ b/Wyam.Modules.Git/GitBase.cs
@@ -17,7 +17,7 @@ namespace Wyam.Modules.Git
             return reposetory.Commits
                 .Select(c => CompareTrees(reposetory, c).Select(x => new { ChangeFile = x, Commit = c }))
                 .SelectMany(x => x)
-                .Select(x => new CommitInformation(x.ChangeFile.Status, new Author(x.Commit.Author), new Author(x.Commit.Committer), x.Commit.Message, x.ChangeFile.Path));
+                .Select(x => new CommitInformation(x.ChangeFile.Status, new Author(x.Commit.Author), new Author(x.Commit.Committer), x.Commit.Message, x.ChangeFile.Path, x.Commit.Sha, x.Commit.Parents.Select(p=>p.Sha)));
         }
 
         protected static IEnumerable<ChangeFile> CompareTrees(Repository repo, Commit toCheck)

--- a/Wyam.Modules.Git/GitCommits.cs
+++ b/Wyam.Modules.Git/GitCommits.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Common.Documents;
+using Wyam.Common.Modules;
+using Wyam.Common.Pipelines;
+using LibGit2Sharp;
+using System.IO;
+using Wyam.Common.Configuration;
+
+namespace Wyam.Modules.Git
+{
+    /// <summary>
+    /// This Module adds an Array with all the CommitInformations that are related with this file to the Metadata.
+    /// </summary>
+    public class GitCommits : GitBase
+    {
+        private readonly string _metadataName;
+
+        public GitCommits(string metadataName)
+        {
+            _metadataName = metadataName;
+        }
+
+        public GitCommits() : this("Commits")
+        {
+
+        }
+
+        public override IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+            var repositoryLocation = Repository.Discover(context.InputFolder);
+            if (repositoryLocation == null)
+                throw new ArgumentException("No git repository found");
+
+            using (Repository repository = new Repository(repositoryLocation))
+            {
+
+                var data = GetCommitInformation(repository);
+                var lookup = data.ToLookup(x => x.Path.ToLower());
+                return inputs.Select(x =>
+                {
+                    string relativePath = GetRelativePath(Path.GetDirectoryName(Path.GetDirectoryName(repositoryLocation.ToLower())), x.Source.ToLower()); // yes we need to do it twice
+                    if (!lookup.Contains(relativePath))
+                        return x;
+
+                    var commitsOfFile = lookup[relativePath].ToArray();
+     
+                    return x.Clone(new[]
+                    {
+                        new KeyValuePair<string, object>(_metadataName, commitsOfFile)
+                    });
+                }).ToArray(); // Don't do it lazy or Commit is disposed.
+            }
+        }
+
+        private string GetRelativePath(string reposotoryLocation, string source)
+        {
+            FilePath repositoryLocationPath = new FilePath(reposotoryLocation);
+            FilePath sourcePath = new FilePath(source);
+            FilePath relativePath = sourcePath.RelativeTo(repositoryLocationPath);
+            return relativePath.ToWindowsPath();
+        }
+
+
+        private class SingelUserDistinction : IEqualityComparer<Author>
+        {
+            public bool Equals(Author x, Author y)
+            {
+                return x.Email == y.Email;
+            }
+
+            public int GetHashCode(Author obj)
+            {
+                return obj.Email.GetHashCode();
+            }
+        }
+
+    }
+}

--- a/Wyam.Modules.Git/GitCommits.cs
+++ b/Wyam.Modules.Git/GitCommits.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Common.Documents;
+using Wyam.Common.Modules;
+using Wyam.Common.Pipelines;
+using LibGit2Sharp;
+using System.IO;
+using Wyam.Common.Configuration;
+
+namespace Wyam.Modules.Git
+{
+    /// <summary>
+    /// This Module Creates a Page for every Commit in the Git repository. Adding Metadata with Information about the Commit.
+    /// </summary>
+    public class GitCommits : GitBase
+    {
+
+        public override IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+            var repositoryLocation = Repository.Discover(context.InputFolder);
+            if (repositoryLocation == null)
+                throw new ArgumentException("No git repository found");
+
+            using (Repository repository = new Repository(repositoryLocation))
+            {
+                IEnumerable<CommitInformation> data = GetCommitInformation(repository);
+
+                var lookup = data.ToLookup(x => x.Sha);
+
+                var newDocuments = lookup.Select(x => context.GetNewDocument(new [] {
+                    new KeyValuePair<string, object>("Sha", x.Key),
+                    new KeyValuePair<string, object>("CommitInformation", x.ToArray())
+                })).ToArray();  // Don't do it lazy or Commit is disposed.
+                return newDocuments;
+            }
+        }
+
+    }
+}

--- a/Wyam.Modules.Git/GitContributor.cs
+++ b/Wyam.Modules.Git/GitContributor.cs
@@ -70,12 +70,12 @@ namespace Wyam.Modules.Git
         {
             public bool Equals(Author x, Author y)
             {
-                return x.Name == y.Name;
+                return x.Email == y.Email;
             }
 
             public int GetHashCode(Author obj)
             {
-                return obj.Name.GetHashCode();
+                return obj.Email.GetHashCode();
             }
         }
 

--- a/Wyam.Modules.Git/GitContributor.cs
+++ b/Wyam.Modules.Git/GitContributor.cs
@@ -42,8 +42,14 @@ namespace Wyam.Modules.Git
                     if (!lookup.Contains(relativePath))
                         return x;
 
-                    var commitsOfFile = lookup[relativePath].Distinct(new SingelUserDistinction()).ToArray();
-                    return x.Clone(new []
+                    var commitsOfFile = lookup[relativePath]
+                        .GroupBy(y => y.Author, new SingelUserDistinction())
+                        .ToDictionary(y => y.Key,
+                                    y => y.OrderByDescending(z => z.Author.DateTime).First())
+                        .Select(y => y.Value)
+                        .ToArray();
+
+                    return x.Clone(new[]
                     {
                         new KeyValuePair<string, object>(_metadataName, commitsOfFile)
                     });
@@ -60,16 +66,16 @@ namespace Wyam.Modules.Git
         }
 
 
-        private class SingelUserDistinction : IEqualityComparer<CommitInformation>
+        private class SingelUserDistinction : IEqualityComparer<Author>
         {
-            public bool Equals(CommitInformation x, CommitInformation y)
+            public bool Equals(Author x, Author y)
             {
-                return x.Author.Name == y.Author.Name;
+                return x.Name == y.Name;
             }
 
-            public int GetHashCode(CommitInformation obj)
+            public int GetHashCode(Author obj)
             {
-                return obj.Author.Name.GetHashCode();
+                return obj.Name.GetHashCode();
             }
         }
 

--- a/Wyam.Modules.Git/GitFileCommits.cs
+++ b/Wyam.Modules.Git/GitFileCommits.cs
@@ -15,16 +15,16 @@ namespace Wyam.Modules.Git
     /// <summary>
     /// This Module adds an Array with all the CommitInformations that are related with this file to the Metadata.
     /// </summary>
-    public class GitCommits : GitBase
+    public class GitFileCommits : GitBase
     {
         private readonly string _metadataName;
 
-        public GitCommits(string metadataName)
+        public GitFileCommits(string metadataName)
         {
             _metadataName = metadataName;
         }
 
-        public GitCommits() : this("Commits")
+        public GitFileCommits() : this("Commits")
         {
 
         }

--- a/Wyam.Modules.Git/Wyam.Modules.Git.csproj
+++ b/Wyam.Modules.Git/Wyam.Modules.Git.csproj
@@ -54,7 +54,7 @@
   <ItemGroup>
     <Compile Include="Author.cs" />
     <Compile Include="CommitInformation.cs" />
-    <Compile Include="GitCommits.cs" />
+    <Compile Include="GitFileCommits.cs" />
     <Compile Include="GitAuthors.cs" />
     <Compile Include="GitBase.cs" />
     <Compile Include="GitContributor.cs" />

--- a/Wyam.Modules.Git/Wyam.Modules.Git.csproj
+++ b/Wyam.Modules.Git/Wyam.Modules.Git.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Author.cs" />
     <Compile Include="CommitInformation.cs" />
+    <Compile Include="GitCommits.cs" />
     <Compile Include="GitAuthors.cs" />
     <Compile Include="GitBase.cs" />
     <Compile Include="GitContributor.cs" />

--- a/Wyam.Modules.Git/Wyam.Modules.Git.csproj
+++ b/Wyam.Modules.Git/Wyam.Modules.Git.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Author.cs" />
     <Compile Include="CommitInformation.cs" />
+    <Compile Include="GitCommits.cs" />
     <Compile Include="GitFileCommits.cs" />
     <Compile Include="GitAuthors.cs" />
     <Compile Include="GitBase.cs" />


### PR DESCRIPTION
## Added Modules
- GitCommits
  Creates a Document for every Commit made, adding the Metadata
  for the corespondending SHA and an array of CommitInformations.
- GitFileCommits
  Looks up what file is associated with each Document, similar to GitContributor
  but instead stores the complete CommitInformation not one per Author.
## Modified
- Added more information to CommitInformation
  - The sha of the commit
  - The sha's of the parents
- The GitContributer Module returned for every Author one CommitInformation
  (Which includes the Author). Previously it was not defined which CommitInformation
  was returnd. Now it is the last Commit Information.
- Two CommitInformations was reagerded to have the same Author if the name
  of the Author Property was the same. Now it uses the Email address.
