### PR TITLE
Fixed a bug and changed the interface a little bit.

### DIFF
--- a/Wyam.Modules.Git/Author.cs
+++ b/Wyam.Modules.Git/Author.cs
@@ -7,13 +7,35 @@ namespace Wyam.Modules.Git
     {
         public string Name { get; }
         public string Email { get; }
-        public DateTimeOffset DateTime { get; }
+
 
         internal Author(Signature committer)
         {
             Name = committer.Name;
             Email = committer.Email;
-            DateTime = committer.When;
+        }
+
+        // override object.Equals
+        public override bool Equals(object obj)
+        {
+
+            if (obj == null || !(obj is Author))
+            {
+                return false;
+            }
+            var otherAuthor = obj as Author;
+            return this.Email.Equals(otherAuthor.Email);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+            return this.Email.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return String.IsNullOrWhiteSpace(Name) ? Email : $"{Name} <{Email}>";
         }
     }
 }

--- a/Wyam.Modules.Git/CommitInformation.cs
+++ b/Wyam.Modules.Git/CommitInformation.cs
@@ -12,18 +12,22 @@ namespace Wyam.Modules.Git
         public string Sha { get; }
         public IEnumerable<string> Parents { get; }
         public Author Author { get; }
+        public DateTimeOffset AuthorDateTime { get; }
         public Author Committer { get; }
+        public DateTimeOffset CommitterDateTime { get; }
         public string Message { get; }
         public ChangeKind Status { get; }
         public string Path { get; private set; }
 
 
 
-        public CommitInformation(ChangeKind status, Author author, Author committer, string message, string path, string sha, IEnumerable<string> parents)
+        public CommitInformation(ChangeKind status, Author author, DateTimeOffset authorTime, Author committer, DateTimeOffset commitTime, string message, string path, string sha, IEnumerable<string> parents)
         {
             this.Status = status;
             this.Author = author;
+            this.AuthorDateTime = authorTime;
             this.Committer = committer;
+            this.CommitterDateTime = commitTime;
             this.Message = message;
             this.Path = path;
             this.Sha = sha;

--- a/Wyam.Modules.Git/GitAuthors.cs
+++ b/Wyam.Modules.Git/GitAuthors.cs
@@ -28,7 +28,7 @@ namespace Wyam.Modules.Git
             {
                 IEnumerable<CommitInformation> data = GetCommitInformation(repository);
 
-                var lookup = data.ToLookup(x => x.Author,new SingelUserDistinction());
+                var lookup = data.ToLookup(x => x.Author);
 
                 var newDocuments = lookup.Select(x => context.GetNewDocument(new [] {
                     new KeyValuePair<string, object>("Contributor", x.Key),

--- a/Wyam.Modules.Git/GitAuthors.cs
+++ b/Wyam.Modules.Git/GitAuthors.cs
@@ -28,7 +28,7 @@ namespace Wyam.Modules.Git
             {
                 IEnumerable<CommitInformation> data = GetCommitInformation(repository);
 
-                var lookup = data.ToLookup(x => x.Author.Name);
+                var lookup = data.ToLookup(x => x.Author,new SingelUserDistinction());
 
                 var newDocuments = lookup.Select(x => context.GetNewDocument(new [] {
                     new KeyValuePair<string, object>("Contributor", x.Key),

--- a/Wyam.Modules.Git/GitBase.cs
+++ b/Wyam.Modules.Git/GitBase.cs
@@ -72,5 +72,18 @@ namespace Wyam.Modules.Git
             public ChangeKind Status { get; set; }
         }
 
+        protected class SingelUserDistinction : IEqualityComparer<Author>
+        {
+            public bool Equals(Author x, Author y)
+            {
+                return x.Email == y.Email;
+            }
+
+            public int GetHashCode(Author obj)
+            {
+                return obj.Email.GetHashCode();
+            }
+        }
+
     }
 }

--- a/Wyam.Modules.Git/GitBase.cs
+++ b/Wyam.Modules.Git/GitBase.cs
@@ -17,7 +17,7 @@ namespace Wyam.Modules.Git
             return reposetory.Commits
                 .Select(c => CompareTrees(reposetory, c).Select(x => new { ChangeFile = x, Commit = c }))
                 .SelectMany(x => x)
-                .Select(x => new CommitInformation(x.ChangeFile.Status, new Author(x.Commit.Author), new Author(x.Commit.Committer), x.Commit.Message, x.ChangeFile.Path, x.Commit.Sha, x.Commit.Parents.Select(p=>p.Sha)));
+                .Select(x => new CommitInformation(x.ChangeFile.Status, new Author(x.Commit.Author), x.Commit.Author.When, new Author(x.Commit.Committer), x.Commit.Author.When, x.Commit.Message, x.ChangeFile.Path, x.Commit.Sha, x.Commit.Parents.Select(p => p.Sha)));
         }
 
         protected static IEnumerable<ChangeFile> CompareTrees(Repository repo, Commit toCheck)
@@ -72,18 +72,6 @@ namespace Wyam.Modules.Git
             public ChangeKind Status { get; set; }
         }
 
-        protected class SingelUserDistinction : IEqualityComparer<Author>
-        {
-            public bool Equals(Author x, Author y)
-            {
-                return x.Email == y.Email;
-            }
-
-            public int GetHashCode(Author obj)
-            {
-                return obj.Email.GetHashCode();
-            }
-        }
 
     }
 }

--- a/Wyam.Modules.Git/GitContributor.cs
+++ b/Wyam.Modules.Git/GitContributor.cs
@@ -43,9 +43,9 @@ namespace Wyam.Modules.Git
                         return x;
 
                     var commitsOfFile = lookup[relativePath]
-                        .GroupBy(y => y.Author, new SingelUserDistinction())
+                        .GroupBy(y => y.Author)
                         .ToDictionary(y => y.Key,
-                                    y => y.OrderByDescending(z => z.Author.DateTime).First())
+                                    y => y.OrderByDescending(z => z.AuthorDateTime).First())
                         .Select(y => y.Value)
                         .ToArray();
 

--- a/Wyam.Modules.Git/GitContributor.cs
+++ b/Wyam.Modules.Git/GitContributor.cs
@@ -66,18 +66,7 @@ namespace Wyam.Modules.Git
         }
 
 
-        private class SingelUserDistinction : IEqualityComparer<Author>
-        {
-            public bool Equals(Author x, Author y)
-            {
-                return x.Email == y.Email;
-            }
-
-            public int GetHashCode(Author obj)
-            {
-                return obj.Email.GetHashCode();
-            }
-        }
+        
 
     }
 }

--- a/Wyam.Modules.Git/GitFileCommits.cs
+++ b/Wyam.Modules.Git/GitFileCommits.cs
@@ -65,18 +65,7 @@ namespace Wyam.Modules.Git
         }
 
 
-        private class SingelUserDistinction : IEqualityComparer<Author>
-        {
-            public bool Equals(Author x, Author y)
-            {
-                return x.Email == y.Email;
-            }
-
-            public int GetHashCode(Author obj)
-            {
-                return obj.Email.GetHashCode();
-            }
-        }
+        
 
     }
 }


### PR DESCRIPTION
## Bug

It was the same Bug that existed in an other class, But this time in GitAuthor Module. I compared the Name of Author instead of email. Now Email will be used instead.
## Change of Class Author

Previously an `IEqualityComparer<Author>` was used to compare the email address instead of the default equals that was inhered from object. The reason was Author also head a field DateTime. Ignoring the DateTime on equality checks seems to be a bead idea.

To change this, the DteTime filed is now owned by CommitInformation. Allowing Author to override the equals Method in a way someone would expect.
### Future Changes that will have to be done

This Project defenetltily need some unit tests. I will check out if I can create some with some test repository that will be copied when testing. This could take some time.
