### PR TITLE
Added ThenBy for OrderBy Module

### DIFF
--- a/Wyam.Core.Tests/Modules/OrderByFixture.cs
+++ b/Wyam.Core.Tests/Modules/OrderByFixture.cs
@@ -75,5 +75,138 @@ namespace Wyam.Core.Tests.Modules
             Assert.AreEqual(8, content.Count);
             CollectionAssert.AreEqual(new[] { "5", "4", "3", "3", "2", "2", "1", "1" }, content);
         }
+
+
+        [Test]
+        public void OrderByOrdersThenByInAscendingOrder()
+        {
+            // Given
+            List<string> content = new List<string>();
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule count = new CountModule("A")
+            {
+                AdditionalOutputs = 4
+            };
+            CountModule count2 = new CountModule("B")
+            {
+                AdditionalOutputs = 1
+            };
+            OrderBy orderBy = new OrderBy((d, c) => d.Get<int>("A"))
+                .ThenBy((d, c) => d.Get<int>("B"));
+            Execute gatherData = new Execute((d, c) =>
+            {
+                content.Add(d.Content);
+                return null;
+            });
+            engine.Pipelines.Add(count, count2, orderBy, gatherData);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
+            CollectionAssert.AreEqual(new[] { "11", "12", "23", "24", "35", "36", "47", "48", "59", "510" }, content);
+        }
+
+        [Test]
+        public void OrderByOrdersThenByInDescendingOrder()
+        {
+            // Given
+            List<string> content = new List<string>();
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule count = new CountModule("A")
+            {
+                AdditionalOutputs = 4
+            };
+            CountModule count2 = new CountModule("B")
+            {
+                AdditionalOutputs = 1
+            };
+            OrderBy orderBy = new OrderBy((d, c) => d.Get<int>("A"))
+                .ThenBy((d, c) => d.Get<int>("B"))
+                .Descending();
+            Execute gatherData = new Execute((d, c) =>
+            {
+                content.Add(d.Content);
+                return null;
+            });
+            engine.Pipelines.Add(count, count2, orderBy, gatherData);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
+            CollectionAssert.AreEqual(new[] { "12", "11", "24", "23", "36", "35", "48", "47", "510", "59" }, content);
+        }
+
+        [Test]
+        public void OrderByOrdersDescendingThenByInDescendingOrder()
+        {
+            // Given
+            List<string> content = new List<string>();
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule count = new CountModule("A")
+            {
+                AdditionalOutputs = 4
+            };
+            CountModule count2 = new CountModule("B")
+            {
+                AdditionalOutputs = 1
+            };
+            OrderBy orderBy = new OrderBy((d, c) => d.Get<int>("A"))
+                .Descending()
+                .ThenBy((d, c) => d.Get<int>("B"))
+                .Descending();
+            Execute gatherData = new Execute((d, c) =>
+            {
+                content.Add(d.Content);
+                return null;
+            });
+            engine.Pipelines.Add(count, count2, orderBy, gatherData);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
+            CollectionAssert.AreEqual(new[] { "510", "59", "48", "47", "36", "35", "24", "23", "12", "11" }, content);
+        }
+
+        [Test]
+        public void OrderByOrdersDescendingThenByInAscendingOrder()
+        {
+            // Given
+            List<string> content = new List<string>();
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule count = new CountModule("A")
+            {
+                AdditionalOutputs = 4
+            };
+            CountModule count2 = new CountModule("B")
+            {
+                AdditionalOutputs = 1
+            };
+            OrderBy orderBy = new OrderBy((d, c) => d.Get<int>("A"))
+                .Descending()
+                .ThenBy((d, c) => d.Get<int>("B"));
+            Execute gatherData = new Execute((d, c) =>
+            {
+                content.Add(d.Content);
+                return null;
+            });
+            engine.Pipelines.Add(count, count2, orderBy, gatherData);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(10, content.Count); // (4+1) * (21+1)
+            CollectionAssert.AreEqual(new[] { "59", "510", "47", "48", "35", "36", "23", "24", "11", "12" }, content);
+        }
     }
 }

--- a/Wyam.Core/Modules/OrderBy.cs
+++ b/Wyam.Core/Modules/OrderBy.cs
@@ -15,6 +15,8 @@ namespace Wyam.Core.Modules
     {
         private readonly DocumentConfig _key;
         private bool _descending;
+        private readonly List<ThenBy> _thenByList = new List<ThenBy>();
+
 
         public OrderBy(DocumentConfig key)
         {
@@ -27,15 +29,32 @@ namespace Wyam.Core.Modules
 
         public OrderBy Descending(bool descending = true)
         {
-            _descending = descending;
+            if (_thenByList.Count == 0)
+                _descending = descending;
+            else
+                _thenByList.Last().Descending = descending;
             return this;
-        } 
+        }
 
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
         {
-            return _descending 
-                ? inputs.OrderByDescending(x => _key(x, context)) 
+            var orderdList = _descending
+                ? inputs.OrderByDescending(x => _key(x, context))
                 : inputs.OrderBy(x => _key(x, context));
+            foreach (var thenBy in _thenByList)
+            {
+                orderdList = thenBy.Descending
+                    ? orderdList.ThenBy(x => thenBy.Key(x, context))
+                    : orderdList.ThenByDescending(x => thenBy.Key(x, context));
+            }
+
+            return orderdList;
+        }
+
+        private class ThenBy
+        {
+            public DocumentConfig Key { get; }
+            public bool Descending { get; set; }
         }
     }
 }

--- a/Wyam.Core/Modules/OrderBy.cs
+++ b/Wyam.Core/Modules/OrderBy.cs
@@ -15,7 +15,7 @@ namespace Wyam.Core.Modules
     {
         private readonly DocumentConfig _key;
         private bool _descending;
-        private readonly List<ThenBy> _thenByList = new List<ThenBy>();
+        private readonly List<ThenByEntry> _thenByList = new List<ThenByEntry>();
 
 
         public OrderBy(DocumentConfig key)
@@ -36,6 +36,18 @@ namespace Wyam.Core.Modules
             return this;
         }
 
+
+        public OrderBy ThenBy(DocumentConfig key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            _thenByList.Add(new ThenByEntry(key));
+            return this;
+        }
+
+
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
         {
             var orderdList = _descending
@@ -44,15 +56,21 @@ namespace Wyam.Core.Modules
             foreach (var thenBy in _thenByList)
             {
                 orderdList = thenBy.Descending
-                    ? orderdList.ThenBy(x => thenBy.Key(x, context))
-                    : orderdList.ThenByDescending(x => thenBy.Key(x, context));
+                    ? orderdList.ThenByDescending(x => thenBy.Key(x, context))
+                    : orderdList.ThenBy(x => thenBy.Key(x, context));
             }
 
             return orderdList;
         }
 
-        private class ThenBy
+        private class ThenByEntry
         {
+
+            public ThenByEntry(DocumentConfig key)
+            {
+                this.Key = key;
+            }
+
             public DocumentConfig Key { get; }
             public bool Descending { get; set; }
         }


### PR DESCRIPTION
- I added A Method ThenBy to the Order By Module.
- I changed Descending so it now sets Descending of the last ThenBy that was added if any, else it has the old meaning.

```
    OrderBy(@doc["m1"])
        .ThenBy(@doc["m2")
        .Descending()
```

Orders the documents first for m1 in ascending then for m2 in descending order.

```
    OrderBy(@doc["m1"])
        .Descending()
        .ThenBy(@doc["m2")
```

Orders the documents first for m1 in descending then for m2 in ascending order.
