### PR TITLE
Added Switch module to support switch-statement logic for modules

### DIFF
--- a/Wyam.Core.Tests/Modules/SwitchFixture.cs
+++ b/Wyam.Core.Tests/Modules/SwitchFixture.cs
@@ -1,0 +1,124 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Core.Modules;
+
+namespace Wyam.Core.Tests.Modules
+{
+    [TestFixture]
+    public class SwitchFixture
+    {
+        [Test]
+        public void SwitchResultsInCorrectCounts()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule a = new CountModule("A") { AdditionalOutputs = 2 };
+            CountModule b = new CountModule("B");
+            CountModule c = new CountModule("C");
+            CountModule d = new CountModule("D");
+
+            engine.Pipelines.Add(a, new Switch((x, y) => x.Content).Case("1", b).Case("2", c).Default(d));
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(1, a.ExecuteCount);
+            Assert.AreEqual(1, b.ExecuteCount);
+            Assert.AreEqual(1, c.ExecuteCount);
+            Assert.AreEqual(1, d.ExecuteCount);
+        }
+
+        [Test]
+        public void SwitchNoCasesResultsInCorrectCounts()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule a = new CountModule("A") { AdditionalOutputs = 2 };
+            CountModule b = new CountModule("B");
+            CountModule c = new CountModule("C");
+
+            engine.Pipelines.Add(a, new Switch((x, y) => x.Content).Default(b), c);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(1, a.ExecuteCount);
+            Assert.AreEqual(1, b.ExecuteCount);
+            Assert.AreEqual(3, b.InputCount);
+            Assert.AreEqual(3, b.OutputCount);
+            Assert.AreEqual(3, c.InputCount);
+        }
+
+        [Test]
+        public void MissingDefaultResultsInCorrectCounts()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule a = new CountModule("A") { AdditionalOutputs = 2 };
+            CountModule b = new CountModule("B");
+            CountModule c = new CountModule("C");
+
+            engine.Pipelines.Add(a, new Switch((x, y) => x.Content).Case("1", b), c);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(1, a.ExecuteCount);
+            Assert.AreEqual(1, b.ExecuteCount);
+            Assert.AreEqual(1, b.InputCount);
+            Assert.AreEqual(1, b.OutputCount);
+            Assert.AreEqual(3, c.InputCount);
+        }
+
+        [Test]
+        public void ArrayInCaseResultsInCorrectCounts()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule a = new CountModule("A") { AdditionalOutputs = 2 };
+            CountModule b = new CountModule("B");
+            CountModule c = new CountModule("C");
+
+            engine.Pipelines.Add(a, new Switch((x, y) => x.Content).Case(new string[] { "1", "2" }, b), c);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(1, a.ExecuteCount);
+            Assert.AreEqual(1, b.ExecuteCount);
+            Assert.AreEqual(2, b.InputCount);
+            Assert.AreEqual(2, b.OutputCount);
+            Assert.AreEqual(3, c.InputCount);
+        }
+
+        [Test]
+        public void OmittingCasesAndDefaultResultsInCorrectCounts()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+            CountModule a = new CountModule("A") { AdditionalOutputs = 2 };
+            CountModule b = new CountModule("B");
+
+            engine.Pipelines.Add(a, new Switch((x, y) => x.Content), b);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual(3, b.InputCount);
+        }
+    }
+}

--- a/Wyam.Core.Tests/Wyam.Core.Tests.csproj
+++ b/Wyam.Core.Tests/Wyam.Core.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Modules\PaginateFixture.cs" />
     <Compile Include="Modules\ReadFilesFixture.cs" />
     <Compile Include="Modules\SitemapFixture.cs" />
+    <Compile Include="Modules\SwitchFixture.cs" />
     <Compile Include="Modules\TraceFixture.cs" />
     <Compile Include="Modules\WriteFilesFixture.cs" />
     <Compile Include="Pipelines\PipelineFixture.cs" />

--- a/Wyam.Core/Modules/Switch.cs
+++ b/Wyam.Core/Modules/Switch.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Common.Configuration;
+using Wyam.Common.Documents;
+using Wyam.Common.Modules;
+using Wyam.Common.Pipelines;
+
+namespace Wyam.Core.Modules
+{
+    public class Switch : IModule
+    {
+        private readonly List<Tuple<object, IModule[]>> _cases
+            = new List<Tuple<object, IModule[]>>();
+        private IModule[] _defaultModules;
+        private DocumentConfig _value;
+
+        /// <summary>
+        /// Must return an object
+        /// </summary>
+        /// <param name="value"></param>
+        public Switch(DocumentConfig value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// value-parameter must be a primitive value or an array of primitives
+        /// </summary>
+        public Switch Case(object value, params IModule[] modules)
+        {
+            _cases.Add(new Tuple<object, IModule[]>(value, modules));
+            return this;
+        }
+
+        public Switch Default(params IModule[] modules)
+        {
+            _defaultModules = modules;
+            return this;
+        }
+
+        public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+            List<IDocument> results = new List<IDocument>();
+            IEnumerable<IDocument> documents = inputs;
+            foreach (Tuple<object, IModule[]> c in _cases)
+            {
+                List<IDocument> handled = new List<IDocument>();
+                List<IDocument> unhandled = new List<IDocument>();
+
+                foreach (IDocument document in documents)
+                {
+                    object switchValue = _value.Invoke(document, context);
+                    object caseValue = c.Item1 ?? Enumerable.Empty<object>();
+                    IEnumerable caseValues = caseValue.GetType().IsArray ? (IEnumerable)caseValue : Enumerable.Repeat(caseValue, 1);
+                    bool matches = caseValues.Cast<object>().Any(cv => object.Equals(switchValue, cv));
+                    
+                    if(matches)
+                    {
+                        handled.Add(document);
+                    }
+                    else
+                    {
+                        unhandled.Add(document);
+                    }
+                }
+
+                results.AddRange(context.Execute(c.Item2, handled));
+                documents = unhandled;
+            }
+
+            if(_defaultModules != null )
+            {
+                results.AddRange(context.Execute(_defaultModules, documents));
+            }
+            else
+            {
+                results.AddRange(documents);
+            }
+
+            return results;
+        }
+    }
+}

--- a/Wyam.Core/Modules/Switch.cs
+++ b/Wyam.Core/Modules/Switch.cs
@@ -54,7 +54,7 @@ namespace Wyam.Core.Modules
                 foreach (IDocument document in documents)
                 {
                     object switchValue = _value.Invoke(document, context);
-                    object caseValue = c.Item1 ?? Enumerable.Empty<object>();
+                    object caseValue = c.Item1 ?? Array.Empty<object>();
                     IEnumerable caseValues = caseValue.GetType().IsArray ? (IEnumerable)caseValue : Enumerable.Repeat(caseValue, 1);
                     bool matches = caseValues.Cast<object>().Any(cv => object.Equals(switchValue, cv));
                     

--- a/Wyam.Core/Wyam.Core.csproj
+++ b/Wyam.Core/Wyam.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Modules\BranchConcat.cs" />
     <Compile Include="Modules\GroupBy.cs" />
     <Compile Include="Modules\Sitemap.cs" />
+    <Compile Include="Modules\Switch.cs" />
     <Compile Include="Modules\UnwrittenFiles.cs" />
     <Compile Include="Modules\Index.cs" />
     <Compile Include="Modules\OrderBy.cs" />


### PR DESCRIPTION
This module should make cases easier, where a `If` module would be too verbose, i.e. to reduce redundant code.
An example would be to use the `Switch` module, to do certain operations depending on the file extension.
Such an example is shown below:

```
// assuming we have four input files: test.txt, test.css, test.xml and test.js,
// which all contain the text "test"
Pipelines.Add("SwitchDemo",
    ReadFiles("*.*"),
    Switch( ((string)@doc["SourceFileExt"]).ToLower() )
    .Case(".js", ReplaceIn("test", "js"))
    .Case(new []{".txt", ".css"}, ReplaceIn("test", "txt or css"))
    .Default(ReplaceIn("test", "default for all other extensions")),
    WriteFiles()
);
```

The fluent `Default` method is optional. Without `Default` method, any document that is not catched by the defined cases, will not be modified.
