### PR TITLE
Fixed a bug in ReplaceIn module

### DIFF
--- a/Wyam.Core.Tests/Modules/ReplaceInFixture.cs
+++ b/Wyam.Core.Tests/Modules/ReplaceInFixture.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Common.Modules;
+using Wyam.Common.Documents;
+using Wyam.Common.Pipelines;
+using Wyam.Core.Modules;
+
+namespace Wyam.Core.Tests.Modules
+{
+    [TestFixture]
+    public class ReplaceInFixture
+    {
+        [Test]
+        public void TestReplaceSuccess()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+
+            DummyTextModule input = new DummyTextModule("Hello World");
+            DummyTextModule output = new DummyTextModule();
+
+            engine.Pipelines.Add(input, new ReplaceIn("Hello", "Goodbye"), output);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual("Goodbye World", output.Text);
+        }
+
+        [Test]
+        public void TestNoMatchingTextSuccess()
+        {
+            // Given
+            Engine engine = new Engine();
+            engine.Trace.AddListener(new TestTraceListener());
+
+            DummyTextModule input = new DummyTextModule("Hello World");
+            DummyTextModule output = new DummyTextModule();
+
+            engine.Pipelines.Add(input, new ReplaceIn("Huhu", "Goodbye"), output);
+
+            // When
+            engine.Execute();
+
+            // Then
+            Assert.AreEqual("Hello World", output.Text);
+        }
+
+        private class DummyTextModule : IModule
+        {
+            public string Text { get; private set; }
+
+            public DummyTextModule(string text = null)
+            {
+                Text = text;
+            }
+
+            public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+            {
+                if (Text != null)
+                {
+                    return inputs.Select(f => f.Clone(Text));
+                }
+                else
+                {
+                    Text = inputs.First().Content;
+                    return inputs;
+                }
+            }
+        }
+    }
+}

--- a/Wyam.Core.Tests/Wyam.Core.Tests.csproj
+++ b/Wyam.Core.Tests/Wyam.Core.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Modules\OrderByFixture.cs" />
     <Compile Include="Modules\PaginateFixture.cs" />
     <Compile Include="Modules\ReadFilesFixture.cs" />
+    <Compile Include="Modules\ReplaceInFixture.cs" />
     <Compile Include="Modules\SitemapFixture.cs" />
     <Compile Include="Modules\TraceFixture.cs" />
     <Compile Include="Modules\WriteFilesFixture.cs" />

--- a/Wyam.Core/Modules/ReplaceIn.cs
+++ b/Wyam.Core/Modules/ReplaceIn.cs
@@ -42,15 +42,19 @@ namespace Wyam.Core.Modules
 
         protected override IEnumerable<IDocument> Execute(object content, IDocument input, IExecutionContext context)
         {
-            if (content == null)
-            {
-                content = string.Empty;
-            }
             if (string.IsNullOrEmpty(_search))
             {
-                return new[] { input.Clone(content.ToString()) };
+                return new[] { input.Clone(input.Content) };
             }
-            return new[] { input.Clone(content.ToString().Replace(_search, input.Content)) };
+
+            string replacement = content as string;
+
+            if (replacement == null )
+            {
+                replacement = string.Empty;
+            }
+            
+            return new[] { input.Clone(input.Content.Replace(_search, replacement)) };
         }
     }
 }


### PR DESCRIPTION
The variables content and input.Content were mixed, so ReplaceIn didn't work in it's old state. Also added a test fixture for ReplaceIn.
