### PR TITLE
Fixes for locked files errors in --watch Wyam mode

### DIFF
--- a/Wyam.Common/IO/SafeIOHelper.cs
+++ b/Wyam.Common/IO/SafeIOHelper.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wyam.Common.IO
+{
+    public static class SafeIOHelper
+    {
+        /// <summary>
+        /// Max SafeOpenRead() attempts
+        /// </summary>
+        /// <see cref="SafeOpenRead(string)"/>
+        private const int _maxAttempts = 3;
+
+        /// <summary>
+        /// Trying to open file via File.OpenRead() several times if first time was not successful, waiting 100 ms between each attempt.
+        /// Often unsuccessful reads are happening while files are being watched for changes.
+        /// </summary>
+        /// <param name="path">Path to the file</param>
+        /// <returns>FileStream, null or base exception</returns>
+        public static FileStream SafeOpenRead(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentException("path");
+
+            int attempts = 0;
+            FileStream file = null;
+
+            while (attempts < _maxAttempts)
+            {
+                try
+                {
+                    attempts++;
+                    file = File.OpenRead(path);
+                    return file;
+                }
+                catch (Exception e)
+                {
+                    if (file != null) file.Dispose();
+
+                    // e is DirectoryNotFoundException || e is FileNotFoundException || 
+                    if (e is IOException || e is UnauthorizedAccessException)
+                        System.Threading.Thread.Sleep(100);
+                    else
+                        throw e;
+                }
+            }
+
+            // must be unreachable
+            return null;
+        }
+    }
+}

--- a/Wyam.Common/Wyam.Common.csproj
+++ b/Wyam.Common/Wyam.Common.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IO\SafeIOHelper.cs" />
     <Compile Include="Meta\CachedDelegateMetadataValue.cs" />
     <Compile Include="Meta\MetadataItems.cs" />
     <Compile Include="Meta\Keys.cs" />

--- a/Wyam.Core/Modules/IO/ReadFiles.cs
+++ b/Wyam.Core/Modules/IO/ReadFiles.cs
@@ -147,7 +147,7 @@ namespace Wyam.Core.Modules.IO
                             .Select(file =>
                             {
                                 context.Trace.Verbose("Read file {0}", file);
-                                return input.Clone(file, File.OpenRead(file), new MetadataItems
+                                return input.Clone(file, SafeIOHelper.SafeOpenRead(file), new MetadataItems
                                 {
                                     { Keys.SourceFileRoot, fileRoot },
                                     { Keys.SourceFileBase, Path.GetFileNameWithoutExtension(file) },


### PR DESCRIPTION
I had experiencing locked file exceptions while editing files in --watch mode using Sublime Text 3, so I created small fix for reading files. Using SafeOpenRead() inside SafeIOHelper to read files inside ReadFiles module.

Probably fixes #108, #92
