### PR TITLE
Fixed multiple console tracers for engine

### DIFF
--- a/src/Wyam/Program.cs
+++ b/src/Wyam/Program.cs
@@ -56,6 +56,7 @@ namespace Wyam
         private DirectoryPath _previewRoot = null;
         private FilePath _configFilePath = null;
         private IReadOnlyList<string> _globalRawMetadata = null;
+        private System.Diagnostics.ConsoleTraceListener _engineListener = null;
 
         private readonly ConcurrentQueue<string> _changedFiles = new ConcurrentQueue<string>();
         private readonly AutoResetEvent _messageEvent = new AutoResetEvent(false);
@@ -356,7 +357,10 @@ namespace Wyam
                 Engine engine = new Engine();
 
                 // Add a default trace listener
-                Trace.AddListener(new SimpleColorConsoleTraceListener() { TraceOutputOptions = System.Diagnostics.TraceOptions.None });
+                if (_engineListener != null)
+                    Trace.RemoveListener(_engineListener);
+                _engineListener = new SimpleColorConsoleTraceListener() { TraceOutputOptions = System.Diagnostics.TraceOptions.None };
+                Trace.AddListener(_engineListener);
 
                 // Set verbose tracing
                 if (_verbose)


### PR DESCRIPTION
Fixed engine trace listener was not removed when requesting new engine which lead to double tracings in console while in --watch mode.

```
...
    Executing pipeline "Resources" (4/5) with 1 child module(s)
    Executing pipeline "Resources" (4/5) with 1 child module(s)
    Executing pipeline "Resources" (4/5) with 1 child module(s)
    Executing pipeline "Resources" (4/5) with 1 child module(s)
    Executing pipeline "Resources" (4/5) with 1 child module(s)
        Executed pipeline "Resources" (4/5) in 18 ms resulting in 38 output document(s)
        Executed pipeline "Resources" (4/5) in 18 ms resulting in 38 output document(s)
        Executed pipeline "Resources" (4/5) in 18 ms resulting in 38 output document(s)
        Executed pipeline "Resources" (4/5) in 18 ms resulting in 38 output document(s)
        Executed pipeline "Resources" (4/5) in 18 ms resulting in 38 output document(s)
    Executing pipeline "Resources (Less)" (5/5) with 3 child module(s)
    Executing pipeline "Resources (Less)" (5/5) with 3 child module(s)
    Executing pipeline "Resources (Less)" (5/5) with 3 child module(s)
    Executing pipeline "Resources (Less)" (5/5) with 3 child module(s)
    Executing pipeline "Resources (Less)" (5/5) with 3 child module(s)
        Executed pipeline "Resources (Less)" (5/5) in 18 ms resulting in 1 output document(s)
        Executed pipeline "Resources (Less)" (5/5) in 18 ms resulting in 1 output document(s)
        Executed pipeline "Resources (Less)" (5/5) in 18 ms resulting in 1 output document(s)
        Executed pipeline "Resources (Less)" (5/5) in 18 ms resulting in 1 output document(s)
        Executed pipeline "Resources (Less)" (5/5) in 18 ms resulting in 1 output document(s)
    Executed 5/5 pipelines in 420 ms
    Executed 5/5 pipelines in 420 ms
    Executed 5/5 pipelines in 420 ms
    Executed 5/5 pipelines in 420 ms
    Executed 5/5 pipelines in 420 ms
Hit any key to exit
Hit any key to exit
Hit any key to exit
Hit any key to exit
Hit any key to exit
```
