### PR TITLE
Fix for verbatim strings in build script.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -196,7 +196,7 @@ Task("Create-Tools-NuGet-Package")
             { 
                 new NuSpecContent 
                 { 
-                    Source = @"bin\" + configuration + @"\**\*",
+                    Source = "bin/" + configuration + "/**/*",
                     Target = "tools"
                 } 
             }


### PR DESCRIPTION
Since the Mono compiler and Roslyn differ in how they treat scripts, we have to do some script massaging before compiling. In this case you use verbatim strings to escape some backslashes that upset our block parser.

For some reason escaping the backslash didn't work either (have to look into this some more) so I resorted to changing them to forward slashes that solved the problem. This should to my knowledge be no problem for the nuspec packing.
