### PR TITLE
Escaped copyright symbol

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -82,7 +82,7 @@ Task("Patch-Assembly-Info")
         var file = "./src/SolutionInfo.cs";
         CreateAssemblyInfo(file, new AssemblyInfoSettings {
             Product = "Wyam",
-            Copyright = "Copyright (c) Wyam Contributors",
+            Copyright = "Copyright \xa9 Wyam Contributors",
             Version = version,
             FileVersion = version,
             InformationalVersion = semVersion

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -9,5 +9,5 @@ using System.Reflection;
 [assembly: AssemblyVersion("0.11.5")]
 [assembly: AssemblyFileVersion("0.11.5")]
 [assembly: AssemblyInformationalVersion("0.11.5-beta")]
-[assembly: AssemblyCopyright("Copyright (c) Wyam Contributors")]
+[assembly: AssemblyCopyright("Copyright \xa9 Wyam Contributors")]
 


### PR DESCRIPTION
Replaces the "(c)" string with an escaped literal character (using hex code),
so to display the correct copyright symbol in the assemblies/executable properties dialog.
