### PR TITLE
Minification code comment corrections

### DIFF
--- a/src/Wyam.Modules.Minification.Tests/MinifyXmlTests.cs
+++ b/src/Wyam.Modules.Minification.Tests/MinifyXmlTests.cs
@@ -27,12 +27,12 @@ namespace Wyam.Modules.Minification.Tests
                             </url>
                             <!-- Content Page -->
                             <url>
-                                <loc>http://wyam.io/modules/xmlminify</loc>
+                                <loc>http://wyam.io/modules/minifyxml</loc>
                                 <changefreq>monthly</changefreq>
                                 <priority>0.7</priority>
                             </url>
                         </urlset>";
-                string output = @"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?><urlset xmlns=""http://www.sitemaps.org/schemas/sitemap/0.9""><url><loc>http://wyam.io/</loc><changefreq>weekly</changefreq><priority>0.9</priority></url><url><loc>http://wyam.io/modules/xmlminify</loc><changefreq>monthly</changefreq><priority>0.7</priority></url></urlset>";
+                string output = @"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?><urlset xmlns=""http://www.sitemaps.org/schemas/sitemap/0.9""><url><loc>http://wyam.io/</loc><changefreq>weekly</changefreq><priority>0.9</priority></url><url><loc>http://wyam.io/modules/minifyxml</loc><changefreq>monthly</changefreq><priority>0.7</priority></url></urlset>";
 
                 IExecutionContext context = Substitute.For<IExecutionContext>();
                 IDocument document = Substitute.For<IDocument>();

--- a/src/Wyam.Modules.Minification/MinifyCss.cs
+++ b/src/Wyam.Modules.Minification/MinifyCss.cs
@@ -16,7 +16,7 @@ namespace Wyam.Modules.Minification
     /// <code>
     /// Pipelines.Add("CSS",
     ///     ReadFiles("*.css"),
-    ///     CssMinify(),
+    ///     MinifyCss(),
     ///     WriteFiles(".css")
     /// );
     /// </code>
@@ -30,7 +30,7 @@ namespace Wyam.Modules.Minification
         /// Minifies the CSS content.
         /// </summary>
         /// <param name="isInlineCode">
-        /// Boolean to specify whether the content has inline CSS code. Default value is <code>false</code>.
+        /// Boolean to specify whether the content has inline CSS code. Default value is <c>false</c>.
         /// </param>
         public MinifyCss(bool isInlineCode = false)
         {
@@ -41,7 +41,7 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Flag for whether the content has inline CSS code.
         /// </summary>
-        /// <param name="isInlineCode">Default value is <code>true</code>.</param>
+        /// <param name="isInlineCode">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyCss IsInlineCode(bool isInlineCode = true)
         {

--- a/src/Wyam.Modules.Minification/MinifyHtml.cs
+++ b/src/Wyam.Modules.Minification/MinifyHtml.cs
@@ -20,7 +20,7 @@ namespace Wyam.Modules.Minification
     ///     FrontMatter(Yaml()),
     ///     Markdown(),
     ///     Razor(),
-    ///     HtmlMinify(),
+    ///     MinifyHtml(),
     ///     WriteFiles(".html")
     /// );
     /// </code>
@@ -35,7 +35,7 @@ namespace Wyam.Modules.Minification
         /// </summary>
         /// <param name="useEmptyMinificationSettings">
         /// Boolean to specify whether to use empty minification settings.
-        /// Default value is <code>false</code>, this will use commonly accepted settings.
+        /// Default value is <c>false</c>, this will use commonly accepted settings.
         /// </param>
         public MinifyHtml(bool useEmptyMinificationSettings = false)
         {
@@ -46,12 +46,12 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Render mode of HTML empty tag. Can take the following values:
         /// <list type="bullets">
-        /// <item><description><code>NoSlash</code>.Without slash(for example, <code>&lt;br&gt;</code>).</description></item>
-        /// <item><description><code>Slash</code>.With slash(for example, <code>&lt;br/&gt;</code>).</description></item>
-        /// <item><description><code>SpaceAndSlash</code>.With space and slash(for example, <code>&lt;br /&gt;</code>).</description></item>
+        /// <item><description><c>NoSlash</c>.Without slash(for example, <c>&lt;br&gt;</c>).</description></item>
+        /// <item><description><c>Slash</c>.With slash(for example, <c>&lt;br/&gt;</c>).</description></item>
+        /// <item><description><c>SpaceAndSlash</c>.With space and slash(for example, <c>&lt;br /&gt;</c>).</description></item>
         /// </list>
         /// </summary>
-        /// <param name="emptyTagRenderMode">Enum type <see cref="WebMarkupMin.Core.HtmlEmptyTagRenderMode"/>; default value is <code>HtmlEmptyTagRenderMode.NoSlash</code></param>
+        /// <param name="emptyTagRenderMode">Enum type <see cref="WebMarkupMin.Core.HtmlEmptyTagRenderMode"/>; default value is <c>HtmlEmptyTagRenderMode.NoSlash</c></param>
         /// <returns>The current instance.</returns>
         public MinifyHtml EmptyTagRenderMode(HtmlEmptyTagRenderMode emptyTagRenderMode = HtmlEmptyTagRenderMode.NoSlash)
         {
@@ -62,7 +62,7 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Flag for whether to remove all HTML comments, except conditional, noindex, KnockoutJS containerless comments and AngularJS comment directives.
         /// </summary>
-        /// <param name="removeHtmlComments">Default value is <code>true</code>.</param>
+        /// <param name="removeHtmlComments">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyHtml RemoveHtmlComments(bool removeHtmlComments = true)
         {
@@ -71,9 +71,9 @@ namespace Wyam.Modules.Minification
         }
 
         /// <summary>
-        /// Flag for whether to remove tags without content, except for <code>textarea</code>, <code>tr</code>, <code>th</code> and <code>td</code> tags, and tags with <code>class</code>, <code>id</code>, <code>name</code>, <code>role</code>, <code>src</code> and <code>data-*</code> attributes.
+        /// Flag for whether to remove tags without content, except for <c>textarea</c>, <c>tr</c>, <c>th</c> and <c>td</c> tags, and tags with <c>class</c>, <c>id</c>, <c>name</c>, <c>role</c>, <c>src</c> and <c>data-*</c> attributes.
         /// </summary>
-        /// <param name="removeTagsWithoutContent">Default value is <code>false</code>.</param>
+        /// <param name="removeTagsWithoutContent">Default value is <c>false</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyHtml RemoveTagsWithoutContent(bool removeTagsWithoutContent = false)
         {
@@ -82,9 +82,9 @@ namespace Wyam.Modules.Minification
         }
 
         /// <summary>
-        /// Flag for whether to remove optional end tags (<code>html</code>, <code>head</code>, <code>body</code>, <code>p</code>, <code>li</code>, <code>dt</code>, <code>dd</code>, <code>rt</code>, <code>rp</code>, <code>optgroup</code>, <code>option</code>, <code>colgroup</code>, <code>thead</code>, <code>tfoot</code>, <code>tbody</code>, <code>tr</code>, <code>th</code> and <code>td</code>).
+        /// Flag for whether to remove optional end tags (<c>html</c>, <c>head</c>, <c>body</c>, <c>p</c>, <c>li</c>, <c>dt</c>, <c>dd</c>, <c>rt</c>, <c>rp</c>, <c>optgroup</c>, <c>option</c>, <c>colgroup</c>, <c>thead</c>, <c>tfoot</c>, <c>tbody</c>, <c>tr</c>, <c>th</c> and <c>td</c>).
         /// </summary>
-        /// <param name="removeOptionalEndTags">Default value is <code>true</code>.</param>
+        /// <param name="removeOptionalEndTags">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyHtml RemoveOptionalEndTags(bool removeOptionalEndTags = true)
         {
@@ -99,7 +99,7 @@ namespace Wyam.Modules.Minification
         /// <returns>The current instance.</returns>
         /// <example>
         /// <code>
-        /// HtmlMinify()
+        /// MinifyHtml()
         ///     .WithSettings(settings =>
         ///     {
         ///         settings.CollapseBooleanAttributes = false;

--- a/src/Wyam.Modules.Minification/MinifyJs.cs
+++ b/src/Wyam.Modules.Minification/MinifyJs.cs
@@ -16,7 +16,7 @@ namespace Wyam.Modules.Minification
     /// <code>
     /// Pipelines.Add("JS",
     ///     ReadFiles("*.js"),
-    ///     Minification(),
+    ///     MinifyJs(),
     ///     WriteFiles(".js")
     /// );
     /// </code>
@@ -30,7 +30,7 @@ namespace Wyam.Modules.Minification
         /// Minifies the JS content.
         /// </summary>
         /// <param name="isInlineCode">
-        /// Boolean to specify whether the content has inline JS code. Default value is <code>false</code>.
+        /// Boolean to specify whether the content has inline JS code. Default value is <c>false</c>.
         /// </param>
         public MinifyJs(bool isInlineCode = false)
         {
@@ -41,7 +41,7 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Flag for whether the content has inline JS code.
         /// </summary>
-        /// <param name="isInlineCode">Default value is <code>true</code>.</param>
+        /// <param name="isInlineCode">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyJs IsInlineCode(bool isInlineCode = true)
         {

--- a/src/Wyam.Modules.Minification/MinifyXhtml.cs
+++ b/src/Wyam.Modules.Minification/MinifyXhtml.cs
@@ -20,7 +20,7 @@ namespace Wyam.Modules.Minification
     ///     FrontMatter(Yaml()),
     ///     Markdown(),
     ///     Razor(),
-    ///     XhtmlMinify(),
+    ///     MinifyXhtml(),
     ///     WriteFiles(".html")
     /// );
     /// </code>
@@ -35,7 +35,7 @@ namespace Wyam.Modules.Minification
         /// </summary>
         /// <param name="useEmptyMinificationSettings">
         /// Boolean to specify whether to use empty minification settings.
-        /// Default value is <code>false</code>, this will use commonly accepted settings.
+        /// Default value is <c>false</c>, this will use commonly accepted settings.
         /// </param>
         public MinifyXhtml(bool useEmptyMinificationSettings = false)
         {
@@ -46,7 +46,7 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Flag for whether to remove all HTML comments, except conditional, noindex, KnockoutJS containerless comments and AngularJS comment directives.
         /// </summary>
-        /// <param name="removeHtmlComments">Default value is <code>true</code>.</param>
+        /// <param name="removeHtmlComments">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyXhtml RemoveHtmlComments(bool removeHtmlComments = true)
         {
@@ -55,9 +55,9 @@ namespace Wyam.Modules.Minification
         }
 
         /// <summary>
-        /// Flag for whether to remove tags without content, except for <code>textarea</code>, <code>tr</code>, <code>th</code> and <code>td</code> tags, and tags with <code>class</code>, <code>id</code>, <code>name</code>, <code>role</code>, <code>src</code> and <code>data-*</code> attributes.
+        /// Flag for whether to remove tags without content, except for <c>textarea</c>, <c>tr</c>, <c>th</c> and <c>td</c> tags, and tags with <c>class</c>, <c>id</c>, <c>name</c>, <c>role</c>, <c>src</c> and <c>data-*</c> attributes.
         /// </summary>
-        /// <param name="removeTagsWithoutContent">Default value is <code>false</code>.</param>
+        /// <param name="removeTagsWithoutContent">Default value is <c>false</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyXhtml RemoveTagsWithoutContent(bool removeTagsWithoutContent = false)
         {
@@ -66,9 +66,9 @@ namespace Wyam.Modules.Minification
         }
 
         /// <summary>
-        /// Flag for whether to allow the inserting space before slash in empty tags (for example, <code>true</code> - <code><br /></code>; <code>false</code> - <code><br/></code>).
+        /// Flag for whether to allow the inserting space before slash in empty tags (for example, <c>true</c> - <c><br /></c>; <c>false</c> - <c><br/></c>).
         /// </summary>
-        /// <param name="renderEmptyTagsWithSpace">Default value is <code>true</code>.</param>
+        /// <param name="renderEmptyTagsWithSpace">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyXhtml RenderEmptyTagsWithSpace(bool renderEmptyTagsWithSpace = true)
         {
@@ -83,7 +83,7 @@ namespace Wyam.Modules.Minification
         /// <returns>The current instance.</returns>
         /// <example>
         /// <code>
-        /// HtmlMinify()
+        /// MinifyXhtml()
         ///     .WithSettings(settings => settings.RemoveHtmlComments = false)
         /// </code>
         /// </example>

--- a/src/Wyam.Modules.Minification/MinifyXml.cs
+++ b/src/Wyam.Modules.Minification/MinifyXml.cs
@@ -20,12 +20,12 @@ namespace Wyam.Modules.Minification
     ///     FrontMatter(Yaml()),
     ///     Markdown(),
     ///     WriteFiles(".html"),
-    ///     Rss(siteRoot: "http://example.org",
-    ///         outputRssFilePath: "posts/feed.rss",
+    ///     Rss(siteUri: "http://example.org",
+    ///         rssPath: new FilePath("posts/feed.rss"),
     ///         feedTitle: "My awesome blog",
     ///         feedDescription: "Blog about something"
     ///     ),
-    ///     XmlMinify(),
+    ///     MinifyXml(),
     ///     WriteFiles()
     /// );
     /// </code>
@@ -40,7 +40,7 @@ namespace Wyam.Modules.Minification
         /// </summary>
         /// <param name="useEmptyMinificationSettings">
         /// Boolean to specify whether to use empty minification settings.
-        /// Default value is <code>false</code>, this will use commonly accepted settings.
+        /// Default value is <c>false</c>, this will use commonly accepted settings.
         /// </param>
         public MinifyXml(bool useEmptyMinificationSettings = false)
         {
@@ -51,7 +51,7 @@ namespace Wyam.Modules.Minification
         /// <summary>
         /// Flag for whether to remove all XML comments.
         /// </summary>
-        /// <param name="removeXmlComments">Default value is <code>true</code>.</param>
+        /// <param name="removeXmlComments">Default value is <c>true</c>.</param>
         /// <returns>The current instance.</returns>
         public MinifyXml RemoveXmlComments(bool removeXmlComments = true)
         {
@@ -66,7 +66,7 @@ namespace Wyam.Modules.Minification
         /// <returns>The current instance.</returns>
         /// <example>
         /// <code>
-        /// XmlMinify()
+        /// MinifyXml()
         ///     .WithSettings(settings => settings.RemoveXmlComments = false)
         /// </code>
         /// </example>


### PR DESCRIPTION
Corrected the markup within the XML code comments.
Replaced multi-line `<code>` tags with inline `<c>` tags.

Corrected the module name within code snippet examples.
