### PR TITLE
Changed Remarks of IDocument to point to the location of Clone

### DIFF
--- a/src/Wyam.Common/Documents/IDocument.cs
+++ b/src/Wyam.Common/Documents/IDocument.cs
@@ -10,7 +10,7 @@ namespace Wyam.Common.Documents
     /// Contains content and metadata for each item as it propagates through the pipeline.
     /// </summary>
     /// <remarks>
-    /// Documents are immutable so you must call one of the <c>Clone</c> methods of <see cref="IDocumentFactory"/> 
+    /// Documents are immutable so you must call one of the <c>GetDocument</c> methods of <see cref="IDocumentFactory"/> 
     /// to create a new document. Implements <see cref="IMetadata"/> and all metadata calls are passed through
     /// to the document's internal <see cref="IMetadata"/> instance (exposed via the <see cref="Metadata"/>
     /// property). Note that both the <see cref="Content"/> property and the result of the <see cref="GetStream"/>

--- a/src/Wyam.Common/Documents/IDocument.cs
+++ b/src/Wyam.Common/Documents/IDocument.cs
@@ -10,12 +10,13 @@ namespace Wyam.Common.Documents
     /// Contains content and metadata for each item as it propagates through the pipeline.
     /// </summary>
     /// <remarks>
-    /// Documents are immutable so you must call one of the <c>Clone</c> methods to create a new document. 
-    /// Implements <see cref="IMetadata"/> and all metadata calls are passed through to the document's internal 
-    /// <see cref="IMetadata"/> instance (exposed via the <see cref="Metadata"/> property). Note that both the 
-    /// <see cref="Content"/> property and the result of the <see cref="GetStream"/> method are guaranteed not 
-    /// to be null. When a document is created, either a string or a <see cref="Stream"/> is provided. Whenever 
-    /// the other of the two is requested, the system will convert the current representation for you.
+    /// Documents are immutable so you must call one of the <c>Clone</c> methods of <see cref="IDocumentFactory"/> 
+    /// to create a new document. Implements <see cref="IMetadata"/> and all metadata calls are passed through
+    /// to the document's internal <see cref="IMetadata"/> instance (exposed via the <see cref="Metadata"/>
+    /// property). Note that both the <see cref="Content"/> property and the result of the <see cref="GetStream"/>
+    /// method are guaranteed not to be null. When a document is created, either a string or a <see cref="Stream"/>
+    /// is provided. Whenever the other of the two is requested, the system will convert the current representation
+    /// for you.
     /// </remarks>
     public interface IDocument : IMetadata, IDisposable
     {


### PR DESCRIPTION
Hi,

the Remarks read like following:
"Documents are immutable so you must call one of the **Clone** methods to create a new document. ..."

I added a link to IDocumentFactory
I think this is related to #240 

Not sure if my change is ok. Languages are not my best subject.
