### PR TITLE
Added Tree Module

### DIFF
--- a/src/Wyam.Core.Tests/Modules/Metadata/TreeMetaTests.cs
+++ b/src/Wyam.Core.Tests/Modules/Metadata/TreeMetaTests.cs
@@ -1,0 +1,762 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using Wyam.Common.Documents;
+using Wyam.Common.IO;
+using Wyam.Common.Meta;
+using Wyam.Common.Execution;
+using Wyam.Core.Modules.Metadata;
+using Wyam.Testing;
+
+namespace Wyam.Core.Tests.Modules.Metadata
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Self | ParallelScope.Children)]
+    public class TreeMetaTests : BaseFixture
+    {
+        public class ExecuteMethodTests : TreeMetaTests
+        {
+
+            [Test]
+            public void TestNumberOfInputiEquealsOutput()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    @"\root",
+                    @"\root\a",
+                    @"\root\a\1",
+                    @"\root\a\2",
+                    @"\root\b",
+                    @"\root\b\1",
+                    @"\root\c",
+                    @"\root\c\2",
+                    @"\root\d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                Assert.AreEqual(inputPathes.Length, outputDocuments.Count);
+            }
+
+            [Test]
+            public void TestAddingMissingNodes()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    @"\root",
+                    @"\root\a\1",
+                    @"\root\a\2",
+                    @"\root\b\1",
+                    @"\root\c\2",
+                    @"\root\d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                Assert.AreEqual(inputPathes.Length + 3, outputDocuments.Count);
+            }
+
+            [Test]
+            public void TestCorrectParent()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+                const string metadatakey = "Parent";
+                Assert.AreEqual(null,
+                    outputLookup[@"/root"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root"],
+                    outputLookup[@"/root/a"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/a/1"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/a/2"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root"],
+                    outputLookup[@"/root/b"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/b/1"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root"],
+                    outputLookup[@"/root/c"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/c/2"][metadatakey]);
+                Assert.AreEqual(outputLookup[@"/root"],
+                    outputLookup[@"/root/d"][metadatakey]);
+            }
+
+            [Test]
+            public void TestAditionalRoots()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree().WithRoots((doc, config) =>
+                {
+                    return doc.Source.Directory.Name == "root";
+                });
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+
+                Assert.AreEqual(0,
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyCollection<IDocument>).Count);
+
+
+                const string metadatakey = "Parent";
+                Assert.AreEqual(null,
+                    outputLookup[@"/root"][metadatakey]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/a"][metadatakey]);
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/a/1"][metadatakey]);
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/a/2"][metadatakey]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/b"][metadatakey]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/b/1"][metadatakey]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/c"][metadatakey]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/c/2"][metadatakey]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/d"][metadatakey]);
+            }
+
+
+            [Test]
+            public void TestCustomOrder()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree().WithOrder((doc, config) =>
+                {
+                    switch (doc.Source.FileName.ToString())
+                    {
+                        case "a":
+                            return 4;
+                        case "b":
+                            return 3;
+                        case "c":
+                            return 2;
+                        case "d":
+                            return 1;
+                        default:
+                            return -1;
+                    }
+                });
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+
+                Assert.AreEqual(outputLookup[@"/root/d"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+
+            }
+
+
+            [Test]
+            public void TestDefaultOrder()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+                Assert.AreEqual(outputLookup[@"/root/d"],
+                    (outputLookup[@"/root"]["Children"] as IReadOnlyList<IDocument>)[0]);
+
+
+            }
+
+
+
+            [Test]
+            public void TestCorrectNext()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+                const string metadataToLookup = "Next";
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/1"],
+                    outputLookup[@"/root/a"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/2"],
+                    outputLookup[@"/root/a/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/a/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b/1"],
+                    outputLookup[@"/root/b"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/b/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c/2"],
+                    outputLookup[@"/root/c"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/d"],
+                    outputLookup[@"/root/c/2"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/d"][metadataToLookup]);
+            }
+            [Test]
+            public void TestCorrectPreview()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+                const string metadataToLookup = "Previous";
+                Assert.AreEqual(null,
+                    outputLookup[@"/root"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root"],
+                    outputLookup[@"/root/a"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/a/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/1"],
+                    outputLookup[@"/root/a/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/2"],
+                    outputLookup[@"/root/b"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/b/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b/1"],
+                    outputLookup[@"/root/c"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/c/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c/2"],
+                    outputLookup[@"/root/d"][metadataToLookup]);
+            }
+
+            public void TestCorrectPreviousSilbling()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+                const string metadataToLookup = "PreviosSilbling";
+                Assert.AreEqual(null,
+                    outputLookup[@"/root"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/a"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/a/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/1"],
+                    outputLookup[@"/root/a/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a"],
+                    outputLookup[@"/root/b"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/b/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/c"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/c/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/d"][metadataToLookup]);
+            }
+
+
+            public void TestCorrectNextSilbling()
+            {
+                // Given
+                IExecutionContext context;
+                IDictionary<string, IDocument> documents;
+                IDictionary<IDocument, int> documentsIndex;
+                Dictionary<IDocument, IDictionary<string, object>> cloneDictionary;
+                String[] inputPathes = new String[]
+                {
+                    "/root",
+                    "/root/a",
+                    "/root/a/1",
+                    "/root/a/2",
+                    "/root/b",
+                    "/root/b/1",
+                    "/root/c",
+                    "/root/c/2",
+                    "/root/d"
+                };
+                Setup(out context, out documents, out documentsIndex, out cloneDictionary, inputPathes);
+
+                Tree directoryMetadata = new Tree();
+
+                // When
+                var outputDocuments = directoryMetadata.Execute(new List<IDocument>(documents.Values), context).ToList();  // Make sure to materialize the result list
+
+                var outputLookup = outputDocuments.ToDictionary(x => x.Source.ToString());
+                const string metadataToLookup = "NextSilbling";
+                Assert.AreEqual(null,
+                    outputLookup[@"/root"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/b"],
+                    outputLookup[@"/root/a"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/a/2"],
+                    outputLookup[@"/root/a/1"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/a/2"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/c"],
+                    outputLookup[@"/root/b"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/b/1"][metadataToLookup]);
+
+                Assert.AreEqual(outputLookup[@"/root/d"],
+                    outputLookup[@"/root/c"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/c/2"][metadataToLookup]);
+
+                Assert.AreEqual(null,
+                    outputLookup[@"/root/d"][metadataToLookup]);
+            }
+
+
+
+
+        }
+
+
+        #region TestHelper
+
+        private const string Root = @"c:\wyam\";
+        private const string SubLocal = @"1\local.metadata";
+        private const string SubInherited = @"1\inherit.metadata";
+        private const string Local = @"local.metadata";
+        private const string Inherited = @"inherit.metadata";
+        private const string SubSite = @"1\site.md";
+        private const string Site = @"site.md";
+
+        /// <summary>
+        /// This Method Helps to Create many Stubs that are used for all tests.
+        /// </summary>
+        /// <param name="context">This is the context that can be used by the test.</param>
+        /// <param name="documents">A dictionary with (relativePath, document)</param>
+        /// <param name="documentsIndexLookup">A directory that has maps an index to every document.</param>
+        /// <param name="cloneDictionary">For every Document that was cloned the new Metadata is stored.</param>
+        /// <param name="pathArray">
+        ///     The Pathes for wich documents will be generated.
+        ///     If empty 6 default documents will be genreated.
+        /// </param>
+        /// <remarks>
+        /// Each document will be generated with metadata.
+        /// 
+        /// The Value of the Metadata is always
+        /// the index that would be returned by the <paramref name="documentsIndexLookup"/>
+        /// for this Document.
+        /// 
+        /// The Key is a string that starts with m and is followed by a number. The total
+        /// number of all different keywords is 2^Number of Documents. And an Document has metadata for all
+        /// Keywords where where the binary representation of the number followed by the m has the nth bit set.
+        /// For every document n is its documentsIndex. 
+        /// </remarks>
+        private void Setup(out IExecutionContext context, out IDictionary<string, IDocument> documents, out IDictionary<IDocument, int> documentsIndexLookup, out Dictionary<IDocument, IDictionary<string, object>> cloneDictionary, params string[] pathArray)
+        {
+            context = GetContext();
+            if (pathArray.Length == 0)
+            {
+                pathArray = new string[]
+                {
+                    Site,
+                    Local,
+                    Inherited,
+                    SubSite,
+                    SubLocal,
+                    SubInherited
+               };
+            }
+
+            var documentsArray = pathArray.Select((path, index) => new
+            {
+                Index = index,
+                Document = GetDocumentWithMetadata(path, GenerateMetadata(index, pathArray.Length).ToArray()),
+                Path = path
+            }).ToArray();
+
+            documents = documentsArray.ToDictionary(x => x.Path, x => x.Document);
+            documentsIndexLookup = documentsArray.ToDictionary(x => x.Document, x => x.Index);
+            Dictionary<IDocument, IDictionary<string, object>> tempDictionary = new Dictionary<IDocument, IDictionary<string, object>>();
+            cloneDictionary = tempDictionary;
+            context.GetDocument(Arg.Any<IDocument>(), Arg.Any<IEnumerable<KeyValuePair<string, object>>>())
+                .Returns(x =>
+                {
+                    IDocument document = x.Arg<IDocument>();
+                    IEnumerable<KeyValuePair<string, object>> newMetadata = x.Arg<IEnumerable<KeyValuePair<string, object>>>();
+
+                    IDocument newDocument = GetDocumentWithMetadata(document?.Source?.ToString(), newMetadata?.ToArray() ?? new KeyValuePair<string, object>[0]);
+
+                    foreach (KeyValuePair<string, object> m in newMetadata) // overriding the old metadata like Document would do it.
+                    {
+                        newDocument.Get<IDocument>(m.Key).Returns(m.Value as IDocument);
+                        newDocument.Get<IReadOnlyList<IDocument>>(m.Key).Returns(m.Value as IReadOnlyList<IDocument>);
+                    }
+
+                    Dictionary<string, object> oldMetadata = document.Metadata.ToDictionary(y => y.Key, y => y.Value);
+                    foreach (KeyValuePair<string, object> m in newMetadata) // overriding the old metadata like Document would do it.
+                    {
+                        oldMetadata[m.Key] = m.Value;
+                    }
+                    tempDictionary[document] = oldMetadata;
+
+
+
+                    return newDocument;
+                });
+            //.Do(x =>
+            //{
+            //    IDocument document = x.Arg<IDocument>();
+            //    IEnumerable<KeyValuePair<string, object>> newMetadata = x.Arg<IEnumerable<KeyValuePair<string, object>>>();
+            //    Dictionary<string, object> oldMetadata = document.Metadata.ToDictionary(y => y.Key, y => y.Value);
+            //    foreach (KeyValuePair<string, object> m in newMetadata) // overriding the old metadata like Document would do it.
+            //    {
+            //        oldMetadata[m.Key] = m.Value;
+            //    }
+            //    tempDictionary[document] = oldMetadata;
+            //});
+        }
+
+        /// <summary>
+        /// Returns the Key of the Metadata that is exactly set in all submitted documents.
+        /// </summary>
+        /// <param name="whereHas">The Documents represented by ther index.</param>
+        /// <returns>The keyword that is only available on the reqired documents.</returns>
+        private string ListMetadata(params int[] whereHas)
+        {
+            return ListAllMetadata(whereHas.Max() + 1, whereHas as IEnumerable<int>).Single();
+        }
+
+        /// <summary>
+        /// Returns all Keywords that are present in <paramref name="whereHas"/> but
+        /// not in <paramref name="whereDoesnt"/>.
+        /// </summary>
+        /// <param name="numberOfDocuments">The total number of documents.</param>
+        /// <param name="whereHas">The Documents that will have the keywords. represented by ther index.</param>
+        /// <param name="whereDoesnt">The Documents that won't have the keywords. represented by ther index.</param>
+        /// <returns>The List of Keywords</returns>
+        private IEnumerable<string> ListAllMetadata(int numberOfDocuments, IEnumerable<int> whereHas, IEnumerable<int> whereDoesnt = null)
+        {
+            whereHas = whereHas ?? Enumerable.Empty<int>();
+            whereDoesnt = whereDoesnt ?? Enumerable.Range(0, numberOfDocuments).Except(whereHas);
+            Func<int, int, bool> check = (index, i) =>
+            {
+                int currentPotenz = (int)Math.Pow(2, index);
+                return (i & currentPotenz) == currentPotenz;
+
+            };
+            for (int i = 0; i < Math.Pow(2, numberOfDocuments); i++)
+            {
+                if (whereHas.All(index => check(index, i)) && whereDoesnt.All(index => !check(index, i)))
+                {
+                    yield return $"m{i}";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates Metadata for a Document with a Specific index.
+        /// </summary>
+        /// <param name="index">The index of the document.</param>
+        /// <param name="numberOfDocuments">The total amount of Documents.</param>
+        /// <returns></returns>
+        private IEnumerable<KeyValuePair<string, object>> GenerateMetadata(int index, int numberOfDocuments)
+        {
+            yield break;
+            int currentPotenz = (int)Math.Pow(2, index);
+            for (int i = 0; i < Math.Pow(2, numberOfDocuments) - 1; i++)
+            {
+                if ((i & currentPotenz) == currentPotenz)
+                {
+                    yield return new KeyValuePair<string, object>($"m{i}", index);
+                }
+            }
+        }
+
+        private static IExecutionContext GetContext()
+        {
+            IExecutionContext context = Substitute.For<IExecutionContext>();
+            AddTryConvert<bool>(context);
+            DirectoryPath inputPath = new DirectoryPath(Root);
+            context.FileSystem.InputPaths.Returns(new[] { inputPath });
+            context.FileSystem.GetContainingInputPath(Arg.Any<NormalizedPath>()).Returns(inputPath);
+            return context;
+        }
+
+        /// <summary>
+        /// Add's convert functionalaty to the ExecutionContext.
+        /// </summary>
+        /// <typeparam name="T">The Type that should be converted.</typeparam>
+        /// <param name="context">The Context that will convert.</param>
+        private static void AddTryConvert<T>(IExecutionContext context)
+        {
+            T anyBool;
+            context.TryConvert(Arg.Any<object>(), out anyBool).ReturnsForAnyArgs(x =>
+            {
+                try
+                {
+                    x[1] = (T)x[0];
+                }
+                catch (InvalidCastException)
+                {
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Creates a stub of a Document.
+        /// </summary>
+        /// <param name="relativePath">The Path of the Document.</param>
+        /// <param name="metadata">The Metadata of the Document.</param>
+        /// <returns></returns>
+        private IDocument GetDocumentWithMetadata(string relativePath, KeyValuePair<string, object>[] metadata)
+        {
+
+            for (int i = 0; i < metadata.Length; i++)
+            {
+                var provider = metadata[i].Value as IMetadataValue;
+                if (provider != null)
+                    metadata[i] = new KeyValuePair<string, object>(metadata[i].Key, provider.Get(metadata[i].Key, null));
+            }
+
+            IDocument document = Substitute.For<IDocument>();
+            IMetadata metadataObject = Substitute.For<IMetadata>();
+
+            metadataObject.GetEnumerator().Returns(x => metadata.OfType<KeyValuePair<string, object>>().GetEnumerator());
+            metadataObject.Keys.Returns(metadata.Select(x => x.Key));
+            metadataObject.Values.Returns(metadata.Select(x => x.Value));
+
+            document.Source.Returns(relativePath == null ? null : Path.Combine(Root, "input", relativePath));
+            document.Metadata.Returns(metadataObject);
+            document.GetEnumerator().Returns(x => metadata.OfType<KeyValuePair<string, object>>().GetEnumerator());
+            document.Keys.Returns(metadata.Select(x => x.Key));
+            document.Values.Returns(metadata.Select(x => x.Value));
+
+            foreach (var m in metadata)
+            {
+                metadataObject[m.Key].Returns(m.Value);
+                metadataObject.ContainsKey(Arg.Any<string>()).Returns((x => metadata.Any(y => y.Key == (string)x[0])));
+
+                document[m.Key].Returns(m.Value);
+                document.ContainsKey(Arg.Any<string>()).Returns((x => metadata.Any(y => y.Key == (string)x[0])));
+            }
+
+            return document;
+        }
+
+        #endregion
+    }
+}

--- a/src/Wyam.Core.Tests/Wyam.Core.Tests.csproj
+++ b/src/Wyam.Core.Tests/Wyam.Core.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Modules\IO\DownloadTests.cs" />
     <Compile Include="Modules\IO\ReadFilesTests.cs" />
     <Compile Include="Modules\IO\UnwrittenFilesTests.cs" />
+    <Compile Include="Modules\Metadata\TreeMetaTests.cs" />
     <Compile Include="Modules\Metadata\DirectoryMetaTests.cs" />
     <Compile Include="Modules\Control\DocumentsTests.cs" />
     <Compile Include="Modules\Extensibility\ExecuteTests.cs" />

--- a/src/Wyam.Core/Modules/Metadata/Tree.cs
+++ b/src/Wyam.Core/Modules/Metadata/Tree.cs
@@ -15,6 +15,13 @@ namespace Wyam.Core.Modules.Metadata
     /// <summary>
     /// Add Metadata to the Documents that describes the position of
     /// the Document in a tree structure. 
+    /// Following keys will be set:
+    /// * Parent (<see cref="IDocument"/>) The parent of this node. <c>null</c> if it is a root
+    /// * Children (<see cref="ReadOnlyCollection{IDocument}"/>) All children of this node.
+    /// * PreviosSilbling (<see cref="IDocument"/>) The previous sibling, that is the previous node in the Children collection of the parent. <c>null</c> if this is the first node in the collection or parent is null.
+    /// * NextSilbling (<see cref="IDocument"/>) The next sibling, that is the next node in the Children collection of the parent. <c>null</c> if this is the last node in the collection or parent is null. 
+    /// * Next (<see cref="IDocument"/>) The next node using a Depth-First-Search. <c>null</c> if this was the last node.
+    /// * Previous (<see cref="IDocument"/>) The previous node using a Depth-First-Search. <c>null</c> if this was the first node.
     /// </summary>
     public class Tree : IModule
     {
@@ -69,7 +76,16 @@ namespace Wyam.Core.Modules.Metadata
             return this;
         }
 
-
+        /// <summary>
+        /// Changes the standard Metadata keys.
+        /// </summary>
+        /// <param name="parentMetadata"></param>
+        /// <param name="childrenMetadata"></param>
+        /// <param name="previousSilblingMetadata"></param>
+        /// <param name="nextSilblingMetadata"></param>
+        /// <param name="nextNodeMetadata"></param>
+        /// <param name="previousNodeMetadata"></param>
+        /// <returns></returns>
         public Tree WithMetadataNames(string parentMetadata = "Parent", string childrenMetadata = "Children", string previousSilblingMetadata = "PreviosSilbling", string nextSilblingMetadata = "NextSilbling", string nextNodeMetadata = "Next", string previousNodeMetadata = "Previous")
         {
             this.parentMetadata = parentMetadata;

--- a/src/Wyam.Core/Modules/Metadata/Tree.cs
+++ b/src/Wyam.Core/Modules/Metadata/Tree.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wyam.Common.Configuration;
+using Wyam.Common.Documents;
+using Wyam.Common.Execution;
+using Wyam.Common.Meta;
+using Wyam.Common.Modules;
+
+namespace Wyam.Core.Modules.Metadata
+{
+    public class Tree : IModule
+    {
+        private DocumentConfig isRoot;
+        private DocumentConfig getPath;
+        private DocumentConfig getOrder;
+
+        private string parentMetadata = "Parent";
+        private string childrenMetadata = "Children";
+        private string previousSilblingMetadata = "PreviosSilbling";
+        private string nextSilblingMetadata = "NextSilbling";
+
+        private string nextNodeMetadata = "Next";
+        private string previousNodeMetadata = "Previous";
+
+
+        public Tree()
+        {
+            isRoot = (ctx, doc) => false;
+            getPath = (doc, ctx) => doc.Source.Segments;
+        }
+
+        /// <summary>
+        /// Specifying for each Document if it is a root of a Tree. This Results in splitting the generated tree in multiple smaller ones.
+        /// </summary>
+        /// <param name="config">A Predicate (must return <c>bool</c>) that specifies if the current Document is treated as the root of a new tree.</param>
+        /// <returns></returns>
+        public Tree WithRoots(DocumentConfig config)
+        {
+            isRoot = config;
+            return this;
+        }
+        /// <summary>
+        /// Specifies the order of the Children in the Tree
+        /// </summary>
+        /// <param name="config">The DocumentConfig must return an <c>int</c>.</param>
+        /// <returns></returns>
+        public Tree WithOrder(DocumentConfig config)
+        {
+            getOrder = config;
+            return this;
+        }
+
+        /// <summary>
+        /// Defines the structure of the Tree
+        /// </summary>
+        /// <param name="config">Must return <c>string[]</c></param>
+        /// <returns></returns>
+        public Tree WithPath(DocumentConfig config)
+        {
+            getPath = config;
+            return this;
+        }
+
+
+
+
+        public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+
+
+            var treeElementLookup = new Dictionary<string, TreeNode<IDocument>>();
+
+            var documentOrder = getOrder != null
+                ? inputs.ToDictionary(x => x, x => (int)getOrder(x, context))
+                : inputs.Select((value, index) => new { Index = index, Document = value }).ToDictionary(x => x.Document, x => x.Index);
+
+            // Generate TreeNodes
+            foreach (var keypair in inputs.Select(x => new { Key = x, Value = (string[])getPath(x, context) }))
+            {
+                var splitedPath = keypair.Value;
+                var document = keypair.Key;
+
+                for (int i = 1; i <= splitedPath.Length; i++)
+                {
+                    string id = System.IO.Path.Combine(splitedPath.Take(i).ToArray());
+                    if (treeElementLookup.ContainsKey(id))
+                        continue;
+                    string parent = System.IO.Path.Combine(splitedPath.Take(i - 1).ToArray());
+                    var treeNode = new TreeNode<IDocument>(id, parent);
+                    if (i == splitedPath.Length)
+                        treeNode.Value = document;
+                    treeElementLookup.Add(id, treeNode);
+                }
+            }
+
+            // Concatenating TreeNodes
+            foreach (var treeElement in treeElementLookup.Values)
+            {
+                treeElement.Parent = treeElement.ParentId == ""
+                    ? null
+                    : treeElementLookup[treeElement.ParentId];
+            }
+            foreach (var treeElement in treeElementLookup.Values)
+            {
+                treeElement.Childrean = treeElementLookup.Values.Where(x => x.ParentId == treeElement.Id).ToList();
+            }
+
+
+            // Order Children
+            foreach (var treeElement in treeElementLookup.Values)
+            {
+                treeElement.Childrean = treeElement.Childrean.OrderBy(x => x.Value != null ? documentOrder[x.Value] : -1).ToList();
+            }
+
+            // Split up Trees
+            foreach (var treeElement in treeElementLookup.Values.Where(x => x.Value != null))
+            {
+                if ((bool)isRoot(treeElement.Value, context))
+                {
+                    treeElement.Parent.Childrean.Remove(treeElement);
+                    treeElement.Parent = null;
+                }
+            }
+
+            // Adding Empty Documents
+            foreach (var treeElement in treeElementLookup.Values.Where(x => x.Value == null))
+            {
+                treeElement.Value = context.GetDocument();
+            }
+
+            // Adding Metadata
+            foreach (var treeElement in treeElementLookup.Values)
+            {
+                treeElement.Value = context.GetDocument(treeElement.Value, new KeyValuePair<string, object>[]
+                {
+                    new KeyValuePair<string, object>(this.childrenMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            new ReadOnlyCollection<IDocument> (treeElement.Childrean.Select(x=>x.Value).ToArray())
+                        )
+                    ),
+                    new KeyValuePair<string,object>(this.parentMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            treeElement.Parent?.Value
+                        )
+                    ),
+                    new KeyValuePair<string,object>(this.nextSilblingMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            GetNextSilbling(treeElement)
+                        )
+                    ),
+                    new KeyValuePair<string,object>(this.previousSilblingMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            GetPreviousSilbling(treeElement)
+                        )
+                    ),
+                    new KeyValuePair<string,object>(this.nextNodeMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            GetNextNodeMetadata(treeElement)
+                        )
+                    ),
+                    new KeyValuePair<string,object>(this.previousNodeMetadata,
+                        new CachedDelegateMetadataValue((str, meta)=>
+                            GetPreviousNode(treeElement)
+                        )
+                    )
+                });
+            }
+
+            return treeElementLookup.Values.Select(x => x.Value);
+        }
+
+        private IDocument GetPreviousNode(TreeNode<IDocument> treeElement)
+        {
+            TreeNode<IDocument> previoussilbling = GetPreviousSilblingTree(treeElement);
+            while (previoussilbling != null && previoussilbling.Childrean.Any())
+            {
+                previoussilbling = previoussilbling.Childrean.Last();
+            }
+            if (previoussilbling != null)
+            {
+                return previoussilbling.Value;
+            }
+
+            return treeElement.Parent?.Value;
+        }
+
+        private IDocument GetNextNodeMetadata(TreeNode<IDocument> treeElement)
+        {
+            // Calculate the next node using Depth-first search
+            if (treeElement.Childrean.Any())
+                return treeElement.Childrean[0].Value;
+
+            var nextSilbling = GetNextSilbling(treeElement);
+            if (nextSilbling != null)
+                return nextSilbling;
+
+            var currentElement = treeElement;
+
+            while (currentElement.Parent != null)
+            {
+                var parrentSilbling = GetNextSilbling(currentElement);
+                if (parrentSilbling != null)
+                    return parrentSilbling;
+                currentElement = currentElement.Parent;
+            }
+            return null;
+        }
+
+        private TreeNode<IDocument> GetPreviousSilblingTree(TreeNode<IDocument> treeElement)
+        {
+            if (treeElement.Parent == null)
+                return null;
+            var indexInParent = treeElement.Parent.Childrean.IndexOf(treeElement);
+            if (indexInParent == 0)
+                return null;
+            return treeElement.Parent.Childrean[indexInParent - 1];
+        }
+
+        private IDocument GetPreviousSilbling(TreeNode<IDocument> treeElement)
+        => GetPreviousSilblingTree(treeElement)?.Value;
+
+        private IDocument GetNextSilbling(TreeNode<IDocument> treeElement)
+        {
+            if (treeElement.Parent == null)
+                return null;
+            var indexInParent = treeElement.Parent.Childrean.IndexOf(treeElement);
+            if (indexInParent == treeElement.Parent.Childrean.Count - 1)
+                return null;
+            return treeElement.Parent.Childrean[indexInParent + 1].Value;
+        }
+
+        [System.Diagnostics.DebuggerDisplay("TreeElement {Id}")]
+        private class TreeNode<T>
+        {
+            public TreeNode(string id, string parentId)
+            {
+                Id = id;
+                ParentId = parentId;
+            }
+            public string Id { get; }
+            public string ParentId { get; }
+            public T Value { get; set; }
+            public TreeNode<T> Parent { get; set; }
+            public List<TreeNode<T>> Childrean { get; set; }
+        }
+    }
+}

--- a/src/Wyam.Core/Modules/Metadata/Tree.cs
+++ b/src/Wyam.Core/Modules/Metadata/Tree.cs
@@ -70,6 +70,17 @@ namespace Wyam.Core.Modules.Metadata
         }
 
 
+        public Tree WithMetadataNames(string parentMetadata = "Parent", string childrenMetadata = "Children", string previousSilblingMetadata = "PreviosSilbling", string nextSilblingMetadata = "NextSilbling", string nextNodeMetadata = "Next", string previousNodeMetadata = "Previous")
+        {
+            this.parentMetadata = parentMetadata;
+            this.childrenMetadata = childrenMetadata;
+            this.previousSilblingMetadata = previousSilblingMetadata;
+            this.nextSilblingMetadata = nextSilblingMetadata;
+            this.nextNodeMetadata = nextNodeMetadata;
+            this.previousNodeMetadata = previousNodeMetadata;
+            return this;
+        }
+
 
 
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)

--- a/src/Wyam.Core/Modules/Metadata/Tree.cs
+++ b/src/Wyam.Core/Modules/Metadata/Tree.cs
@@ -12,6 +12,10 @@ using Wyam.Common.Modules;
 
 namespace Wyam.Core.Modules.Metadata
 {
+    /// <summary>
+    /// Add Metadata to the Documents that describes the position of
+    /// the Document in a tree structure. 
+    /// </summary>
     public class Tree : IModule
     {
         private DocumentConfig isRoot;

--- a/src/Wyam.Core/Wyam.Core.csproj
+++ b/src/Wyam.Core/Wyam.Core.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Modules\Metadata\Index.cs" />
     <Compile Include="Modules\Control\OrderBy.cs" />
     <Compile Include="Modules\Control\Paginate.cs" />
+    <Compile Include="Modules\Metadata\Tree.cs" />
     <Compile Include="Modules\ModuleExtensions.cs" />
     <Compile Include="Modules\Metadata\ValidateMeta.cs" />
     <Compile Include="Modules\Templates\Xslt.cs" />


### PR DESCRIPTION
Created a Tree Module (as in #150), that adds Metadata to each document that represents the tree structure.
The Module takes a DocumentConfig that returns for each Document a `string[]`. This is used to generate the tree.

Every Document get Metadata added to navigate around.

In addition for each Document a bool can hint to split the Tree on that node. Removing the node from the original tree and creating an additional tree with the node as root.

Actually I'm not sure if the last thing is needed. I think it could also be archived when manipulating the path that describs the tree structure.
