### PR TITLE
Sidecar file

### DIFF
--- a/src/Wyam.Configuration.Tests/Wyam.Configuration.Tests.csproj
+++ b/src/Wyam.Configuration.Tests/Wyam.Configuration.Tests.csproj
@@ -84,6 +84,9 @@
       <Name>Wyam.Testing</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Wyam.Core.Tests/Modules/Control/SidecarTests.cs
+++ b/src/Wyam.Core.Tests/Modules/Control/SidecarTests.cs
@@ -9,6 +9,14 @@ using Wyam.Core.Modules.Extensibility;
 using Wyam.Core.Execution;
 using Wyam.Testing;
 using Wyam.Common.IO;
+using Wyam.Testing.IO;
+using NSubstitute;
+using System.IO;
+using Wyam.Common.Meta;
+using System.Text;
+using Wyam.Common.Modules;
+using System.Collections.ObjectModel;
+using System;
 
 namespace Wyam.Core.Tests.Modules.Control
 {
@@ -23,37 +31,164 @@ namespace Wyam.Core.Tests.Modules.Control
             {
                 // Given
                 Engine engine = new Engine();
-                Pipeline pipeline = new Pipeline("Pipeline", null);
-                IExecutionContext context = new ExecutionContext(engine, pipeline);
+                IExecutionContext context = GetExecutionContext(engine);
 
-                string documentContent = "I'm document content";
-                string sidecarContent = "I'm sidecar content";
-
-                string documentPath = "/test.md";
-                string sidecarPath = "/test.md.meta";
-
+                string documentContent = "File a1";
+                string sidecarContent = "data: a1";
 
                 IDocument[] inputs =
                 {
-                    context.GetDocument((FilePath)documentPath, "")
+                    GetDocument("a/1.md", "File a1")
                 };
                 string lodedSidecarContent = null;
                 Sidecar sidecar = new Sidecar(new Execute((x, ctx) =>
                 {
                     lodedSidecarContent = x.Content;
-                    return new[] { x };
+                    return new IDocument[] { x };
                 }));
 
                 // When
-                IEnumerable<IDocument> documents = sidecar.Execute(inputs, context);
+                IEnumerable<IDocument> documents = sidecar.Execute(inputs, context).ToArray();
 
                 // Then
 
                 Assert.AreEqual(sidecarContent, lodedSidecarContent);
                 Assert.AreEqual(documentContent, documents.Single().Content);
-
-
             }
+
+            [Test]
+            public void LoadsCustomSidecarFile()
+            {
+                // Given
+                Engine engine = new Engine();
+                IExecutionContext context = GetExecutionContext(engine);
+
+                string documentContent = "File a1";
+                string sidecarContent = "data: other";
+
+                IDocument[] inputs =
+                {
+                    GetDocument("a/1.md", "File a1")
+                };
+                string lodedSidecarContent = null;
+                Sidecar sidecar = new Sidecar(".other", new Execute((x, ctx) =>
+                 {
+                     lodedSidecarContent = x.Content;
+                     return new IDocument[] { x };
+                 }));
+
+                // When
+                IEnumerable<IDocument> documents = sidecar.Execute(inputs, context).ToArray();
+
+                // Then
+
+                Assert.AreEqual(sidecarContent, lodedSidecarContent);
+                Assert.AreEqual(documentContent, documents.Single().Content);
+            }
+
+            private IDocument GetDocument(string source, string content)
+            {
+                IDocument document = Substitute.For<IDocument>();
+                document.Source.Returns(new FilePath("/" + source));
+
+                document.ContainsKey(Keys.RelativeFilePath).Returns(true);
+                document.String(Keys.RelativeFilePath).Returns(source);
+
+                document.ContainsKey(Keys.SourceFilePath).Returns(true);
+                document.String(Keys.SourceFilePath).Returns("/" + source);
+                document.FilePath(Keys.SourceFilePath).Returns(new FilePath("/" + source));
+
+                document.ContainsKey(Keys.SourceFileName).Returns(true);
+                document.FilePath(Keys.SourceFileName).Returns(new FilePath(source).FileName);
+
+                document.Content.Returns(content);
+                document.GetStream().Returns(
+                    new MemoryStream(Encoding.UTF8.GetBytes(content)),
+                    new MemoryStream(Encoding.UTF8.GetBytes(content)));  // Return a new memory stream if called again
+                return document;
+            }
+
+            private IExecutionContext GetExecutionContext(Engine engine)
+            {
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                context.Assemblies.Returns(engine.Assemblies);
+                context.Namespaces.Returns(engine.Namespaces);
+                IReadOnlyFileSystem fileSystem = GetFileSystem();
+                context.FileSystem.Returns(fileSystem);
+                FilePath result;
+
+                context.GetDocument(Arg.Any<IDocument>(), Arg.Any<string>(), Arg.Any<IEnumerable<KeyValuePair<string, object>>>()).Returns(x =>
+                {
+                    IDocument document = (IDocument)x[0];
+                    string content = (string)x[1];
+                    return GetDocument(document.Source.FullPath, content);
+                });
+
+                context.GetDocument(Arg.Any<IDocument>(), Arg.Any<IEnumerable<KeyValuePair<string, object>>>()).Returns(x =>
+                {
+                    IDocument document = (IDocument)x[0];
+                    string content = document.Content;
+                    return GetDocument(document.Source.FullPath, content);
+                });
+
+                context.Execute(Arg.Any<IEnumerable<IModule>>(), Arg.Any<IEnumerable<IDocument>>()).Returns(x =>
+                {
+                    IModule[] modules = ((IEnumerable<IModule>)x[0]).ToArray();
+                    IEnumerable<IDocument> documents = (IEnumerable<IDocument>)x[1];
+
+                    for (int i = 0; i < modules.Length; i++)
+                    {
+                        documents = modules[i].Execute(new ReadOnlyCollection<IDocument>(documents.ToList()), context);
+                    }
+
+
+                    return new ReadOnlyCollection<IDocument>(documents.ToArray());
+                });
+                context.TryConvert(Arg.Any<object>(), out result).Returns(x =>
+                {
+                    x[1] = (FilePath)x[0];
+                    return true;
+                });
+                return context;
+            }
+
+            private IReadOnlyFileSystem GetFileSystem()
+            {
+                IReadOnlyFileSystem fileSystem = Substitute.For<IReadOnlyFileSystem>();
+                IFileProvider fileProvider = GetFileProvider();
+                fileSystem.GetInputFile(Arg.Any<FilePath>()).Returns(x =>
+                {
+                    FilePath path = x.ArgAt<FilePath>(0);
+                    if (!path.IsAbsolute)
+                    {
+                        path = new FilePath("/" + path.FullPath);
+                    }
+                    return fileProvider.GetFile(path);
+                });
+                fileSystem.GetInputDirectory(Arg.Any<DirectoryPath>()).Returns(x => fileProvider.GetDirectory(x.ArgAt<DirectoryPath>(0)));
+                return fileSystem;
+            }
+
+            private IFileProvider GetFileProvider()
+            {
+                TestFileProvider fileProvider = new TestFileProvider();
+
+                fileProvider.AddDirectory("/");
+                fileProvider.AddDirectory("/a");
+                fileProvider.AddDirectory("/b");
+
+                fileProvider.AddFile("/a/1.md", @"File a1");
+                fileProvider.AddFile("/a/1.md.meta", @"data: a1");
+                fileProvider.AddFile("/a/1.md.other", @"data: other");
+                fileProvider.AddFile("/a/2.md", @"File a2");
+                fileProvider.AddFile("/a/2.md.meta", @"data: a2");
+
+                fileProvider.AddFile("/b/1.md", @"File b1");
+                fileProvider.AddFile("/b/1.md.meta", @"data: b1");
+
+                return fileProvider;
+            }
+
 
         }
     }

--- a/src/Wyam.Core.Tests/Modules/Control/SidecarTests.cs
+++ b/src/Wyam.Core.Tests/Modules/Control/SidecarTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Wyam.Common.Documents;
+using Wyam.Common.Execution;
+using Wyam.Core.Documents;
+using Wyam.Core.Modules.Control;
+using Wyam.Core.Modules.Extensibility;
+using Wyam.Core.Execution;
+using Wyam.Testing;
+using Wyam.Common.IO;
+
+namespace Wyam.Core.Tests.Modules.Control
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Self | ParallelScope.Children)]
+    public class SideCarTests : BaseFixture
+    {
+        public class ExecuteMethodTests : FrontMatterTests
+        {
+            [Test]
+            public void LoadsSidecarFile()
+            {
+                // Given
+                Engine engine = new Engine();
+                Pipeline pipeline = new Pipeline("Pipeline", null);
+                IExecutionContext context = new ExecutionContext(engine, pipeline);
+
+                string documentContent = "I'm document content";
+                string sidecarContent = "I'm sidecar content";
+
+                string documentPath = "/test.md";
+                string sidecarPath = "/test.md.meta";
+
+
+                IDocument[] inputs =
+                {
+                    context.GetDocument((FilePath)documentPath, "")
+                };
+                string lodedSidecarContent = null;
+                Sidecar sidecar = new Sidecar(new Execute((x, ctx) =>
+                {
+                    lodedSidecarContent = x.Content;
+                    return new[] { x };
+                }));
+
+                // When
+                IEnumerable<IDocument> documents = sidecar.Execute(inputs, context);
+
+                // Then
+
+                Assert.AreEqual(sidecarContent, lodedSidecarContent);
+                Assert.AreEqual(documentContent, documents.Single().Content);
+
+
+            }
+
+        }
+    }
+}

--- a/src/Wyam.Core.Tests/Wyam.Core.Tests.csproj
+++ b/src/Wyam.Core.Tests/Wyam.Core.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="EngineTests.cs" />
     <Compile Include="Meta\MetadataStackTests.cs" />
     <Compile Include="Modules\Control\BranchTests.cs" />
+    <Compile Include="Modules\Control\SidecarTests.cs" />
     <Compile Include="Modules\Control\MergeTests.cs" />
     <Compile Include="Modules\Control\ModuleCollectionTests.cs" />
     <Compile Include="Modules\IO\CopyFilesTests.cs" />

--- a/src/Wyam.Core/Modules/Control/Sidecar.cs
+++ b/src/Wyam.Core/Modules/Control/Sidecar.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wyam.Common.Documents;
+using Wyam.Common.Modules;
+using Wyam.Common.Execution;
+using Wyam.Common.IO;
+using Wyam.Common.Meta;
+
+namespace Wyam.Core.Modules.Control
+{
+    /// <summary>
+    /// Extracts the content of a Sidecar file for each document and sends it to a child module for processing.
+    /// </summary>
+    /// <remarks>
+    /// This module is typically used in conjunction with the Yaml module to enable putting YAML in a Sidecar file
+    /// in a file. First, for each File it is searched for a Sidecar file. Once found, the 
+    /// content in this file is passed to the specified child modules. Any metadata from the child
+    /// module output document(s) is added to the input document. Note that if the child modules result 
+    /// in more than one output document, multiple clones of the input document will be made for each one. 
+    /// The output document content is set to the original content.
+    /// </remarks>
+    /// <category>Control</category>
+    public class Sidecar : IModule
+    {
+        private readonly string _extension;
+        private readonly IModule[] _modules;
+
+        /// <summary>
+        /// Uses the default delimiter character and passes any front matter to the specified child modules for processing.
+        /// </summary>
+        /// <param name="modules">The modules to execute against the front matter.</param>
+        public Sidecar(params IModule[] modules)
+        {
+            _extension = ".meta";
+            _modules = modules;
+        }
+
+        /// <summary>
+        /// Uses the specified delimiter string and passes any front matter to the specified child modules for processing.
+        /// </summary>
+        /// <param name="extension">The delimiter to use.</param>
+        /// <param name="modules">The modules to execute against the front matter.</param>
+        public Sidecar(string extension, params IModule[] modules)
+        {
+            _extension = extension;
+            _modules = modules;
+        }
+
+        public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+            foreach (IDocument input in inputs)
+            {
+
+
+                FilePath sourceFilePath = input.FilePath(Keys.SourceFilePath);
+                if (sourceFilePath != null)
+                {
+                    IFile sidecarFile = context.FileSystem.GetInputFile(sourceFilePath.FullPath + _extension);
+                    if (sidecarFile.Exists)
+                    {
+                        string frontMatter = sidecarFile.ReadAllText();
+                        foreach (IDocument result in context.Execute(_modules, new[] { context.GetDocument(input, frontMatter) }))
+                        {
+                            yield return context.GetDocument(input, result);
+                        }
+                    }
+                    else
+                    {
+                        yield return input;
+                    }
+                }
+                else
+                {
+                    yield return input;
+                }
+            }
+        }
+    }
+}

--- a/src/Wyam.Core/Wyam.Core.csproj
+++ b/src/Wyam.Core/Wyam.Core.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Modules\Control\Combine.cs" />
     <Compile Include="Modules\Contents\Rss.cs" />
     <Compile Include="Modules\Contents\SitemapItem.cs" />
+    <Compile Include="Modules\Control\Sidecar.cs" />
     <Compile Include="Modules\Control\Merge.cs" />
     <Compile Include="Modules\Control\ModuleCollection.cs" />
     <Compile Include="Modules\Control\Take.cs" />


### PR DESCRIPTION
Implementing a Module for [Sidecar Files](https://en.wikipedia.org/wiki/Sidecar_file).

This allows to add Metadata to Documents without modifying the content of the document. The Metadata for the File `Test.xml` would be stored in `Test.xml.meta`.

Like FrontMatter this module dos not process Metadata itself. It uses other Modules to do this.

This Module can be usefull with binary formats or text files that can not add FrontMatter without lousing editor support for autocompletion or syntaxhilighting.
