### PR TITLE
Markdig

### DIFF
--- a/src/Wyam.Markdown.Tests/MarkdownTests.cs
+++ b/src/Wyam.Markdown.Tests/MarkdownTests.cs
@@ -41,6 +41,96 @@ namespace Wyam.Markdown.Tests
             }
 
             [Test]
+            public void DoesNotRenderSpecialAttributesByDefault()
+            {
+                // Given
+                string input = @"[link](url){#id .class}";
+                string output = @"<p><a href=""url"">link</a>{#id .class}</p>
+".Replace(Environment.NewLine, "\n");
+                IDocument document = Substitute.For<IDocument>();
+                document.Content.Returns(input);
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                Markdown markdown = new Markdown();
+
+                // When
+                markdown.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+                // Then
+                context.Received(1).GetDocument(Arg.Any<IDocument>(), Arg.Any<string>());
+                context.Received().GetDocument(document, output);
+            }
+
+            [Test]
+            public void DoesRenderSpecialAttributesIfExtensionsActive()
+            {
+                // Given
+                string input = @"[link](url){#id .class}";
+                string output = @"<p><a href=""url"" id=""id"" class=""class"">link</a></p>
+".Replace(Environment.NewLine, "\n");
+                IDocument document = Substitute.For<IDocument>();
+                document.Content.Returns(input);
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                Markdown markdown = new Markdown().UseExtensions();
+
+                // When
+                markdown.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+                // Then
+                context.Received(1).GetDocument(Arg.Any<IDocument>(), Arg.Any<string>());
+                context.Received().GetDocument(document, output);
+            }
+
+            [Test]
+            public void DoesNotRenderDefinitionListWithoutExtensions()
+            {
+                // Given
+                string input = @"Apple
+:   Pomaceous fruit of plants of the genus Malus in 
+    the family Rosaceae.";
+                string output = @"<p>Apple
+:   Pomaceous fruit of plants of the genus Malus in
+the family Rosaceae.</p>
+".Replace(Environment.NewLine, "\n");
+                IDocument document = Substitute.For<IDocument>();
+                document.Content.Returns(input);
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                Markdown markdown = new Markdown();
+
+                // When
+                markdown.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+                // Then
+                context.Received(1).GetDocument(Arg.Any<IDocument>(), Arg.Any<string>());
+                context.Received().GetDocument(document, output);
+            }
+
+            [Test]
+            public void DoesRenderDefintionListWithSpecificConfiguration()
+            {
+                // Given
+                string input = @"Apple
+:   Pomaceous fruit of plants of the genus Malus in 
+    the family Rosaceae.";
+                string output = @"<dl>
+<dt>Apple</dt>
+<dd>Pomaceous fruit of plants of the genus Malus in
+the family Rosaceae.</dd>
+</dl>
+".Replace(Environment.NewLine, "\n");
+                IDocument document = Substitute.For<IDocument>();
+                document.Content.Returns(input);
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                Markdown markdown = new Markdown().UseConfiguration("definitionlists");
+
+                // When
+                markdown.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+                // Then
+                context.Received(1).GetDocument(Arg.Any<IDocument>(), Arg.Any<string>());
+                context.Received().GetDocument(document, output);
+            }
+
+            [Test]
             public void EscapesAtByDefault()
             {
                 // Given

--- a/src/Wyam.Markdown.Tests/MarkdownTests.cs
+++ b/src/Wyam.Markdown.Tests/MarkdownTests.cs
@@ -1,14 +1,11 @@
-﻿using System;
+﻿using NSubstitute;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using NSubstitute;
-using System.IO;
 using Wyam.Common.Documents;
-using Wyam.Common.Meta;
 using Wyam.Common.Execution;
+using Wyam.Common.Meta;
 using Wyam.Testing;
 
 namespace Wyam.Markdown.Tests
@@ -29,8 +26,7 @@ namespace Wyam.Markdown.Tests
                 string output = @"<p>Line 1
 <em>Line 2</em></p>
 <h1>Line 3</h1>
-
-";
+".Replace(Environment.NewLine, "\n");
                 IDocument document = Substitute.For<IDocument>();
                 document.Content.Returns(input);
                 IExecutionContext context = Substitute.For<IExecutionContext>();
@@ -50,8 +46,7 @@ namespace Wyam.Markdown.Tests
                 // Given
                 string input = @"Looking @Good, Man!";
                 string output = @"<p>Looking &#64;Good, Man!</p>
-
-";
+".Replace(Environment.NewLine, "\n");
                 IDocument document = Substitute.For<IDocument>();
                 document.Content.Returns(input);
                 IExecutionContext context = Substitute.For<IExecutionContext>();
@@ -71,8 +66,7 @@ namespace Wyam.Markdown.Tests
                 // Given
                 string input = @"Looking @Good, Man!";
                 string output = @"<p>Looking @Good, Man!</p>
-
-";
+".Replace(Environment.NewLine, "\n");
                 IDocument document = Substitute.For<IDocument>();
                 document.Content.Returns(input);
                 IExecutionContext context = Substitute.For<IExecutionContext>();
@@ -96,8 +90,7 @@ namespace Wyam.Markdown.Tests
                 string output = @"<p>Line 1
 <em>Line 2</em></p>
 <h1>Line 3</h1>
-
-";
+".Replace(Environment.NewLine, "\n");
 
                 IDocument document = Substitute.For<IDocument>();
                 document.ContainsKey("meta").Returns(true);
@@ -127,8 +120,7 @@ namespace Wyam.Markdown.Tests
                 string output = @"<p>Line 1
 <em>Line 2</em></p>
 <h1>Line 3</h1>
-
-";
+".Replace(Environment.NewLine, "\n");
 
                 IDocument document = Substitute.For<IDocument>();
                 document.ContainsKey("meta").Returns(true);

--- a/src/Wyam.Markdown/Wyam.Markdown.csproj
+++ b/src/Wyam.Markdown/Wyam.Markdown.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommonMark, Version=0.1.0.0, Culture=neutral, PublicKeyToken=001ef8810438905d, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonMark.NET.0.10.0\lib\net45\CommonMark.dll</HintPath>
+    <Reference Include="Markdig, Version=0.7.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.7.4\lib\net40\Markdig.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Wyam.Markdown/packages.config
+++ b/src/Wyam.Markdown/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonMark.NET" version="0.10.0" targetFramework="net46" />
+  <package id="Markdig" version="0.7.4" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Regarding #165 I did the following:
- Replaced CommonMark.NET with Markdig (using the default HTML Renderer)
- Extended the Markdown extension (pun intended) with Markdig specific methods (to fully utilize it for further use cases)
- Adjusted the unit tests (all of them had 1 more new line - which was specific to CommonMark.NET; however, now we need to use `\n` instead of the system's newline - this is specific to Markdig)*

*) This is pretty much hardwired; we could change it by self-creating the `HtmlRenderer` instance with a `TextWriter` that does use the environment's newline sequence. However, I thought being cross platform also means that `\n` should be preferred instead of the Windows specific `\r\n` being produced on Windows.

There could be more points of extension, e.g., allowing the user to use other renderers or making the pipeline more open (right now one may choose between all of the available extensions and include new extensions, but the the core parsers cannot be modified).

Nevertheless, the PR should be sufficient to close #165 - more additions should be handled in more issues (and specified with all requirements).
