### PR TITLE
Inverted order of tags

### DIFF
--- a/themes/Blog/CleanBlog/index.cshtml
+++ b/themes/Blog/CleanBlog/index.cshtml
@@ -32,7 +32,7 @@
         <hr class="visible-xs-block" />
         <h5>Tags</h5>
         <div>
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
+            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
             { 
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();

--- a/themes/Blog/Phantom/index.cshtml
+++ b/themes/Blog/Phantom/index.cshtml
@@ -25,7 +25,7 @@
     <div class="4u 12u$(medium)">
         <h5>Tags</h5>
         <ul class="actions small">
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
+            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
             { 
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();


### PR DESCRIPTION
Tags used to be ordered by most to least used but in the new themes
they're ordered least to most used. This commit changes the "OrderBy" to
and "OrderByDescending" to revert to original functionality
