### PR TITLE
Sitemap - adds support for locations with HTTPS

### DIFF
--- a/src/Wyam.Core/Modules/Contents/Sitemap.cs
+++ b/src/Wyam.Core/Modules/Contents/Sitemap.cs
@@ -114,7 +114,8 @@ namespace Wyam.Core.Modules.Contents
                     // Apply the hostname if defined (and the location formatter didn't already set a hostname)
                     if (!string.IsNullOrWhiteSpace(location))
                     {
-                        if (!location.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase))
+                        if (!location.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase)
+                            && !location.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase))
                         {
                             location = context.GetLink(new FilePath(location), true);
                         }


### PR DESCRIPTION
When generating a sitemap with items that have HTTPS, the Sitemap module will fail when attempting to get the link for the URL.

This patch adds a condition to check if HTTPS have already been set on the item's URL.
