### PR TITLE
Fixed bug that BaseUri was not always set in Xslt2 module. 

### DIFF
--- a/src/extensions/Wyam.Xslt2/Xslt2.cs
+++ b/src/extensions/Wyam.Xslt2/Xslt2.cs
@@ -115,9 +115,9 @@ namespace Wyam.Xslt2
                     {
                         XmlReader xml = XmlReader.Create(stream);
 
-                        var documentBuilder = processor.NewDocumentBuilder();
+                        Saxon.Api.DocumentBuilder documentBuilder = processor.NewDocumentBuilder();
                         documentBuilder.BaseUri = xslt.BaseUri;
-                        var xdmNode = documentBuilder.Build(xml);
+                        Saxon.Api.XdmNode xdmNode = documentBuilder.Build(xml);
                         transformer.InitialContextNode = xdmNode;
 
                         using (System.IO.StringWriter writer = new StringWriter())
@@ -140,7 +140,7 @@ namespace Wyam.Xslt2
 
         private static Saxon.Api.XsltTransformer LoadXsltDataInTransformer(Saxon.Api.XsltCompiler xslt, Stream stream)
         {
-            var xml = XmlReader.Create(stream);
+            XmlReader xml = XmlReader.Create(stream);
             xslt.BaseUri = new Uri(string.IsNullOrEmpty(xml.BaseURI) ? "http://NOT.SET" : xml.BaseURI);
             Saxon.Api.XsltExecutable executable = xslt.Compile(xml);
             Saxon.Api.XsltTransformer transformer = executable.Load();

--- a/src/extensions/Wyam.Xslt2/Xslt2.cs
+++ b/src/extensions/Wyam.Xslt2/Xslt2.cs
@@ -84,8 +84,7 @@ namespace Wyam.Xslt2
                             {
                                 using (Stream fileStream = file.OpenRead())
                                 {
-                                    Saxon.Api.XsltExecutable executable = xslt.Compile(fileStream);
-                                    transformer = executable.Load();
+                                    transformer = LoadXsltDataInTransformer(xslt, fileStream);
                                 }
                             }
                             else
@@ -103,11 +102,7 @@ namespace Wyam.Xslt2
                         IDocument xsltDocument = context.Execute(_xsltGeneration, new[] { input }).Single();
                         using (Stream stream = xsltDocument.GetStream())
                         {
-
-                            var xml = XmlReader.Create(stream);
-                            xslt.BaseUri  = new Uri(string.IsNullOrEmpty( xml.BaseURI)?"http://temp.org": xml.BaseURI);
-                            Saxon.Api.XsltExecutable executable = xslt.Compile(xml);
-                            transformer = executable.Load();
+                            transformer = LoadXsltDataInTransformer(xslt, stream);
                         }
                     }
                     else
@@ -118,11 +113,13 @@ namespace Wyam.Xslt2
 
                     using (Stream stream = input.GetStream())
                     {
+                        XmlReader xml = XmlReader.Create(stream);
+
                         var documentBuilder = processor.NewDocumentBuilder();
                         documentBuilder.BaseUri = xslt.BaseUri;
-                        var xdmNode = documentBuilder.Build(stream);
+                        var xdmNode = documentBuilder.Build(xml);
                         transformer.InitialContextNode = xdmNode;
-                        
+
                         using (System.IO.StringWriter writer = new StringWriter())
                         {
                             Saxon.Api.Serializer serializer = new Saxon.Api.Serializer();
@@ -139,6 +136,15 @@ namespace Wyam.Xslt2
                     return null;
                 }
             }).Where(x => x != null);
+        }
+
+        private static Saxon.Api.XsltTransformer LoadXsltDataInTransformer(Saxon.Api.XsltCompiler xslt, Stream stream)
+        {
+            var xml = XmlReader.Create(stream);
+            xslt.BaseUri = new Uri(string.IsNullOrEmpty(xml.BaseURI) ? "http://NOT.SET" : xml.BaseURI);
+            Saxon.Api.XsltExecutable executable = xslt.Compile(xml);
+            Saxon.Api.XsltTransformer transformer = executable.Load();
+            return transformer;
         }
     }
 }


### PR DESCRIPTION
Only when _xsltGeneration was used the BaseUri got set. using _xsltPath did not set this. This could result in an exception even when the BaseUri is not needed.