### PR TITLE
Remove top margin from paragraph when in blockquote

### DIFF
--- a/themes/Blog/CleanBlog/assets/css/clean-blog.css
+++ b/themes/Blog/CleanBlog/assets/css/clean-blog.css
@@ -34,6 +34,9 @@ blockquote {
   color: #555555;
   font-style: italic;
 }
+blockquote > p {
+  margin-top: 0;
+}
 hr.small {
   max-width: 100px;
   margin: 15px auto;


### PR DESCRIPTION
When a blockquote is used inside a blog post using CleanBlog theme, it shows a top margin. This margin is useful for single p-tags. But inside the blockquote-tag it is not needed.

Currently, it looks like this:
![image](https://cloud.githubusercontent.com/assets/13137880/22245034/3550aa0e-e22e-11e6-9f9c-b9e1c58483ab.png)

This simple CSS change makes it look like this:
![image](https://cloud.githubusercontent.com/assets/13137880/22245035/38f42e7e-e22e-11e6-93bf-11d62368c42f.png)
