### PR TITLE
Sets MSBuild to use max # of CPUs when building

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -105,10 +105,12 @@ Task("Build")
         {
             MSBuild("./Wyam.sln", new MSBuildSettings()
                 .SetConfiguration(configuration)
+                .SetMaxCpuCount(0)
                 .SetVerbosity(Verbosity.Minimal)
             );
             MSBuild("./Wyam.Windows.sln", new MSBuildSettings()
                 .SetConfiguration(configuration)
+                .SetMaxCpuCount(0)
                 .SetVerbosity(Verbosity.Minimal)
             );
         }


### PR DESCRIPTION
MSBuild defaults to building projects one by one. By setting the CPU count to 0 it will use the max number of CPUs on the machine. This cuts the build time in half on my machine.

Before

```
Task                          Duration
--------------------------------------------------
Clean                         00:00:00.0079030
Restore-Packages              00:00:00.7753753
Patch-Assembly-Info           00:00:00.0066169
Build                         00:00:06.8159808
--------------------------------------------------
Total:                        00:00:07.6058760
```

After

```
Task                          Duration
--------------------------------------------------
Clean                         00:00:00.0079091
Restore-Packages              00:00:00.7765120
Patch-Assembly-Info           00:00:00.0064566
Build                         00:00:03.9991782
--------------------------------------------------
Total:                        00:00:04.7900559
```

Just a handful of seconds on my machine, but I notice that on appVeyor it was taking 20+s for a build so maybe this will help there more significantly. But every second counts, right? :-)