### PR TITLE
Adds additional extension to Markdown renderer to allow multiple markdig extensions

### DIFF
--- a/src/extensions/Wyam.Blog/Blog.cs
+++ b/src/extensions/Wyam.Blog/Blog.cs
@@ -38,7 +38,7 @@ namespace Wyam.Blog
             engine.Pipelines.Add(BlogPipelines.Pages,
                 new ReadFiles(ctx => $"{{!{ctx.DirectoryPath(BlogKeys.PostsPath).FullPath},**}}/*.md"),
                 new FrontMatter(new Yaml.Yaml()),
-                new Execute(ctx => new Markdown.Markdown().UseConfiguration(ctx.String(BlogKeys.MarkdownExtensions))),
+                new Execute(ctx => new Markdown.Markdown().UseExtensions(ctx.Settings[BlogKeys.MarkdownExternalExtensions] as IEnumerable<Type>).UseConfiguration(ctx.String(BlogKeys.MarkdownExtensions))),
                 new Concat(
                     // Add any additional Razor pages
                     new ReadFiles(ctx => $"{{!{ctx.DirectoryPath(BlogKeys.PostsPath).FullPath},!tags,**}}/*.cshtml"),
@@ -67,7 +67,7 @@ namespace Wyam.Blog
             engine.Pipelines.Add(BlogPipelines.RawPosts,
                 new ReadFiles(ctx => $"{ctx.DirectoryPath(BlogKeys.PostsPath).FullPath}/*.md"),
                 new FrontMatter(new Yaml.Yaml()),
-                new Execute(ctx => new Markdown.Markdown().UseConfiguration(ctx.String(BlogKeys.MarkdownExtensions))),
+                new Execute(ctx => new Markdown.Markdown().UseExtensions(ctx.Settings[BlogKeys.MarkdownExternalExtensions] as IEnumerable<Type>).UseConfiguration(ctx.String(BlogKeys.MarkdownExtensions))),
                 new Concat(
                     // Add any posts written in Razor
                     new ReadFiles(ctx => $"{ctx.DirectoryPath(BlogKeys.PostsPath).FullPath}/{{!_,!index,}}*.cshtml"),

--- a/src/extensions/Wyam.Blog/BlogKeys.cs
+++ b/src/extensions/Wyam.Blog/BlogKeys.cs
@@ -82,6 +82,14 @@ namespace Wyam.Blog
         public const string MarkdownExtensions = nameof(MarkdownExtensions);
 
         /// <summary>
+        /// Set this to add extension Markdown extensions for the Markdig Markdown
+        /// renderer. The default value is null;
+        /// </summary>
+        /// <scope>Global</scope>
+        /// <type><see cref="IEnumerable{IMarkDownExtension}"/></type>
+        public const string MarkdownExternalExtensions = nameof(MarkdownExternalExtensions);
+
+        /// <summary>
         /// Setting this to <c>true</c> uses
         /// the year and date in the output path of blog posts.
         /// The default value is <c>false</c>.

--- a/src/extensions/Wyam.Docs/Docs.cs
+++ b/src/extensions/Wyam.Docs/Docs.cs
@@ -86,7 +86,7 @@ namespace Wyam.Docs
                 new Meta(DocsKeys.EditFilePath, (doc, ctx) => doc.FilePath(Keys.RelativeFilePath)),
                 new Include(),
                 new FrontMatter(new Yaml.Yaml()),
-                new Execute(ctx => new Markdown.Markdown().UseConfiguration(ctx.String(DocsKeys.MarkdownExtensions))),
+                new Execute(ctx => new Markdown.Markdown().UseExtensions(ctx.Settings[DocsKeys.MarkdownExternalExtensions] as IEnumerable<Type>).UseConfiguration(ctx.String(DocsKeys.MarkdownExtensions))),
                 new Concat(
                     // Add any additional Razor pages
                     new ReadFiles(ctx => $"{{{GetIgnoreFoldersGlob(ctx)}}}/{{!_,}}*.cshtml"),
@@ -114,7 +114,7 @@ namespace Wyam.Docs
                 new ReadFiles("blog/*.md"),
                 new Meta(DocsKeys.EditFilePath, (doc, ctx) => doc.FilePath(Keys.RelativeFilePath)),
                 new FrontMatter(new Yaml.Yaml()),
-                new Execute(ctx => new Markdown.Markdown().UseConfiguration(ctx.String(DocsKeys.MarkdownExtensions))),
+                new Execute(ctx => new Markdown.Markdown().UseExtensions(ctx.Settings[DocsKeys.MarkdownExternalExtensions] as IEnumerable<Type>).UseConfiguration(ctx.String(DocsKeys.MarkdownExtensions))),
                 new If(ctx => ctx.Bool(DocsKeys.AutoLinkTypes),
                     new AutoLink(_typeNamesToLink)
                         .WithQuerySelector("code")

--- a/src/extensions/Wyam.Docs/DocsKeys.cs
+++ b/src/extensions/Wyam.Docs/DocsKeys.cs
@@ -99,6 +99,14 @@ namespace Wyam.Docs
         public const string MarkdownExtensions = nameof(MarkdownExtensions);
 
         /// <summary>
+        /// Set this to add extension Markdown extensions for the Markdig Markdown
+        /// renderer. The default value is null;
+        /// </summary>
+        /// <scope>Global</scope>
+        /// <type><see cref="IEnumerable{IMarkDownExtension}"/></type>
+        public const string MarkdownExternalExtensions = nameof(MarkdownExternalExtensions);
+
+        /// <summary>
         /// This should be a string or array of strings with the name(s)
         /// of root-level folders to ignore when scanning for content pages.
         /// Setting this global metadata value is useful when introducing

--- a/src/extensions/Wyam.Markdown/Markdown.cs
+++ b/src/extensions/Wyam.Markdown/Markdown.cs
@@ -1,4 +1,5 @@
-﻿using Markdig;
+﻿using System;
+using Markdig;
 using Markdig.Helpers;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,6 +89,29 @@ namespace Wyam.Markdown
             where TExtension : class, IMarkdownExtension, new()
         {
             _extensions.AddIfNotAlready<TExtension>();
+            return this;
+        }
+
+        /// <summary>
+        /// Includes multiple custom extension in the markdown processing given by classes implementing
+        /// the IMarkdownExtension interface.
+        /// </summary>
+        public Markdown UseExtensions(IEnumerable<Type> extensions)
+        {
+            if (extensions == null)
+            {
+                return this;
+            }
+
+            foreach (var type in extensions)
+            {
+                var extension = Activator.CreateInstance(type) as IMarkdownExtension;
+                if (extension != null)
+                {
+                    _extensions.AddIfNotAlready(extension);
+                }
+            }
+
             return this;
         }
 

--- a/tests/extensions/Wyam.Markdown.Tests/ExternalMarkdownExtension.cs
+++ b/tests/extensions/Wyam.Markdown.Tests/ExternalMarkdownExtension.cs
@@ -1,0 +1,38 @@
+﻿using Markdig;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Wyam.Markdown.Tests
+{
+    class ExternalMarkdownExtension : IMarkdownExtension
+    {
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+            // Make sure we don't have a delegate twice
+            pipeline.DocumentProcessed -= PipelineOnDocumentProcessed;
+            pipeline.DocumentProcessed += PipelineOnDocumentProcessed;
+        }
+
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+        }
+
+
+        private static void PipelineOnDocumentProcessed(MarkdownDocument document)
+        {
+            foreach (var node in document.Descendants())
+            {
+                if (node is Inline)
+                {
+                    var link = node as LinkInline;
+                    if (link != null && link.IsImage)
+                    {
+                        link.GetAttributes().AddClass("ui spaced image");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
+++ b/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
@@ -41,6 +41,27 @@ namespace Wyam.Markdown.Tests
             }
 
             [Test]
+            public void CanUseExternalExtension()
+            {
+                string input = @"![Alt text](/path/to/img.jpg)";
+                string output = @"<p><img src=""/path/to/img.jpg"" class=""ui spaced image"" alt=""Alt text"" /></p>
+".Replace(Environment.NewLine, "\n");
+                IDocument document = Substitute.For<IDocument>();
+                document.Content.Returns(input);
+                IExecutionContext context = Substitute.For<IExecutionContext>();
+                var o = new Type[] {typeof(ExternalMarkdownExtension)};
+                var cast = o as IEnumerable<Type>;
+                Markdown markdown = new Markdown().UseExtensions(cast);
+
+                // When
+                markdown.Execute(new[] { document }, context).ToList();  // Make sure to materialize the result list
+
+                // Then
+                context.Received(1).GetDocument(Arg.Any<IDocument>(), Arg.Any<string>());
+                context.Received().GetDocument(document, output);
+            }
+
+            [Test]
             public void DoesNotRenderSpecialAttributesByDefault()
             {
                 // Given

--- a/tests/extensions/Wyam.Markdown.Tests/Wyam.Markdown.Tests.csproj
+++ b/tests/extensions/Wyam.Markdown.Tests/Wyam.Markdown.Tests.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Markdig, Version=0.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Markdig.0.10.4\lib\net40\Markdig.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
@@ -49,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExternalMarkdownExtension.cs" />
     <Compile Include="MarkdownFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\..\SolutionInfo.cs">

--- a/tests/extensions/Wyam.Markdown.Tests/packages.config
+++ b/tests/extensions/Wyam.Markdown.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Markdig" version="0.10.4" targetFramework="net462" />
   <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
   <package id="NUnit" version="3.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Ran into an issue today with the extensibility of markdig when using recipes. I wanted to use Semantic-UI in a theme rather than bootstrap. All good until I started messing with tables. Semantic-UI wants a `ui table` css class on the tables similar to how bootstrap wants `table`. So I set about creating an extension for Markdig to support this. I could wire it up just fine, but to do so I had to override the recipe steps. The current setting only allows a string to be specified, and with this being custom it isn't in there obviously. So to get this custom extension added it involved copy and paste of both the `Pages` and `RawPosts` pipelines into the config file.

My proof of concept here adds a new setting for Blog and Docs named `MarkdownExternalExtensions`. It's an array of types. If nothing is set it continues as usual. Otherwise it applies them then applies the settings specified by the `MarkdownExtensions` property. The usage ends up looking like this

```
#n Markdig.SemanticUi
#recipe Blog

Settings[BlogKeys.MarkdownExtensions] = "advanced"; // get rid of default bootstrap
Settings[BlogKeys.MarkdownExternalExtensions] = new Type[] { typeof(Markdig.SemanticUi.SemanticUiExtension) };
```

I'm not a huge fan of the type array here, but short of letting Markdig leak all over the place I couldn't think of a cleaner way to do this so. Definitely up for suggestions.

Thoughts?