### PR TITLE
Fixes condition to look for nulls in phantom theme footer

### DIFF
--- a/themes/Blog/Phantom/_Footer.cshtml
+++ b/themes/Blog/Phantom/_Footer.cshtml
@@ -3,10 +3,10 @@
         @if (Context.String(BlogKeys.RssPath) != null && Context.String(BlogKeys.AtomPath) != null) {
         <h2>Feeds</h2>
         <ul class="actions small vertical">
-            @if (Context.String(BlogKeys.RssPath)) {
+            @if (Context.String(BlogKeys.RssPath) != null) {
             <li><a href="@Context.GetLink(Context.String(BlogKeys.RssPath))" class="button small"><i class="fa fa-rss"></i> RSS Feed</a></li>
             }
-            @if (Context.String(BlogKeys.AtomPath)) {
+            @if (Context.String(BlogKeys.AtomPath) != null) {
             <li><a href="@Context.GetLink(Context.String(BlogKeys.AtomPath))" class="button small"><i class="fa fa-rss"></i> Atom Feed</a></li>
             }
         </ul>


### PR DESCRIPTION
Using the phantom theme was throwing an exception rendering the footer
due to the lack of a proper conditional. Adjusts it to check for null.