### PR TITLE
Uses BlogPipelines constants rather than BlogKeys

### DIFF
--- a/themes/Blog/CleanBlog/_PostHeader.cshtml
+++ b/themes/Blog/CleanBlog/_PostHeader.cshtml
@@ -21,7 +21,7 @@
         <div class="tags">
             @foreach (string tag in Tags.OrderBy(x => x))
             {
-                IDocument tagDocument = Documents[BlogKeys.Tags].FirstOrDefault(x => x.String(BlogKeys.Tag) == tag);
+                IDocument tagDocument = Documents[BlogPipelines.Tags].FirstOrDefault(x => x.String(BlogKeys.Tag) == tag);
                 if(tagDocument != null)
                 {                
                     <a role="button" href="@Context.GetLink(tagDocument)" class="btn btn-default btn-xs">@tag</a>

--- a/themes/Blog/CleanBlog/index.cshtml
+++ b/themes/Blog/CleanBlog/index.cshtml
@@ -6,7 +6,7 @@
     <div class="col-sm-8 right-border">
         @{
             bool first = true;
-            foreach(IDocument doc in Documents[BlogKeys.Posts].Take(3))
+            foreach(IDocument doc in Documents[BlogPipelines.Posts].Take(3))
             {                
                 if (!first)
                 {
@@ -32,7 +32,7 @@
         <hr class="visible-xs-block" />
         <h5>Tags</h5>
         <div>
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
+            @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
             { 
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();
@@ -47,7 +47,7 @@
         <hr />
         <h5>Older Posts</h5>
         <ul class="list-unstyled">
-            @foreach(IDocument doc in Documents[BlogKeys.Posts].Skip(3).Take(4))
+            @foreach(IDocument doc in Documents[BlogPipelines.Posts].Skip(3).Take(4))
             {        
                 <li><a href="@Context.GetLink(doc)">@doc.WithoutSettings.String(BlogKeys.Title)</a></li>
             }

--- a/themes/Blog/CleanBlog/posts/index.cshtml
+++ b/themes/Blog/CleanBlog/posts/index.cshtml
@@ -5,7 +5,7 @@ Title: Archive
 }
 
 @{
-    foreach(IGrouping<int, IDocument> year in Documents[BlogKeys.Posts]
+    foreach(IGrouping<int, IDocument> year in Documents[BlogPipelines.Posts]
         .Where(x => x.ContainsKey("Published"))
         .OrderByDescending(x => x.Get<DateTime>("Published"))
         .GroupBy(x => x.Get<DateTime>("Published").Year)

--- a/themes/Blog/CleanBlog/tags/index.cshtml
+++ b/themes/Blog/CleanBlog/tags/index.cshtml
@@ -3,7 +3,7 @@ Title: All Tags
 <div class="container-sm-height">
     <div class="row row-sm-height">		
         <div class="col-sm-12 col-sm-height">            
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
+            @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
             {
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();

--- a/themes/Blog/CleanBlog/tags/tag.cshtml
+++ b/themes/Blog/CleanBlog/tags/tag.cshtml
@@ -8,7 +8,7 @@ Title: All Tags
         </div>
 		
         <div class="col-sm-4 col-sm-height">
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
+            @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
             {
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();

--- a/themes/Blog/Phantom/_PostHeader.cshtml
+++ b/themes/Blog/Phantom/_PostHeader.cshtml
@@ -19,7 +19,7 @@
         <ul class="actions small">
             @foreach (string tag in Tags.OrderBy(x => x))
             {
-                IDocument tagDocument = Documents[BlogKeys.Tags].FirstOrDefault(x => x.String(BlogKeys.Tag) == tag);
+                IDocument tagDocument = Documents[BlogPipelines.Tags].FirstOrDefault(x => x.String(BlogKeys.Tag) == tag);
                 if(tagDocument != null)
                 {                
                     <li><a role="button" href="@Context.GetLink(tagDocument)" class="button small">@tag</a></li>

--- a/themes/Blog/Phantom/index.cshtml
+++ b/themes/Blog/Phantom/index.cshtml
@@ -5,7 +5,7 @@
 <div class="row">
     <div class="8u 12u$(medium)">
         @{
-            foreach(IDocument doc in Documents[BlogKeys.Posts].Take(3))
+            foreach(IDocument doc in Documents[BlogPipelines.Posts].Take(3))
             {                
                 string lead = doc.String(BlogKeys.Lead);
                 <div>
@@ -25,7 +25,7 @@
     <div class="4u 12u$(medium)">
         <h5>Tags</h5>
         <ul class="actions small">
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
+            @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderByDescending(x => x.DocumentList(BlogKeys.Posts).Count()).Take(10))
             { 
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();
@@ -37,7 +37,7 @@
         </ul>
         <h5>Older Posts</h5>
         <ul>
-            @foreach(IDocument doc in Documents[BlogKeys.Posts].Skip(3).Take(4))
+            @foreach(IDocument doc in Documents[BlogPipelines.Posts].Skip(3).Take(4))
             {        
                 <li><a href="@Context.GetLink(doc)">@doc.String(BlogKeys.Title)</a></li>
             }

--- a/themes/Blog/Phantom/posts/index.cshtml
+++ b/themes/Blog/Phantom/posts/index.cshtml
@@ -5,7 +5,7 @@ Title: Archive
 }
 
 @{
-    foreach(IGrouping<int, IDocument> year in Documents[BlogKeys.Posts]
+    foreach(IGrouping<int, IDocument> year in Documents[BlogPipelines.Posts]
         .Where(x => x.ContainsKey("Published"))
         .OrderByDescending(x => x.Get<DateTime>("Published"))
         .GroupBy(x => x.Get<DateTime>("Published").Year)

--- a/themes/Blog/Phantom/tags/index.cshtml
+++ b/themes/Blog/Phantom/tags/index.cshtml
@@ -1,7 +1,7 @@
 Title: All Tags
 ---
 <ul class="actions small">           
-    @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
+    @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
     {
         string tag = tagDocument.String(BlogKeys.Tag);
         string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();

--- a/themes/Blog/Phantom/tags/tag.cshtml
+++ b/themes/Blog/Phantom/tags/tag.cshtml
@@ -7,7 +7,7 @@ Title: All Tags
     
     <div class="4u 12u$(medium)">
         <ul class="actions small">
-            @foreach (IDocument tagDocument in Documents[BlogKeys.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
+            @foreach (IDocument tagDocument in Documents[BlogPipelines.Tags].OrderBy(x => x.String(BlogKeys.Tag)))
             {
                 string tag = tagDocument.String(BlogKeys.Tag);
                 string postCount = tagDocument.DocumentList(BlogKeys.Posts).Count().ToString();


### PR DESCRIPTION
This is a subtle one, but it threw me off when learning how pipelines and
the such work. `BlogKeys.Posts` and `BlogKeys.Tags` both are string constants
with the same value was `BlogPipelines.Posts` and `BlogPipelines.Tags`
respectfully. I was kind of turned around wondering the significance of
`BlogKeys` in relationship to the output of pipelines until I put it
together that the value is all that matters.

This simply swaps the constant being used and keeps the value the same so
there shouldn't be any breaking changes for people using the theme.

One thing of note - the phantom theme still has an error with a
conditional check in `_footer.cshtml`. PR #433 resolves this