### PR TITLE
WIP: Adds helper functions to Pipeline for modifying module list

### DIFF
--- a/src/core/Wyam.Common/Modules/IModuleCollectionExtensions.cs
+++ b/src/core/Wyam.Common/Modules/IModuleCollectionExtensions.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wyam.Common.Modules
+{
+    public static class ModuleCollectionExtensions
+    {
+        public static void InsertAfter(this IModuleCollection moduleCollection, string name, params IModule[] modules) 
+            => moduleCollection.Insert(moduleCollection.GuardIndexOf(name) + 1, modules);
+
+        public static void InsertBefore(this IModuleCollection moduleCollection, string name, params IModule[] modules) 
+            => moduleCollection.Insert(moduleCollection.GuardIndexOf(name), modules);
+
+        public static void InsertBeforeFirst<T>(this IModuleCollection moduleCollection, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.InsertBeforeFirst<T>(_ => true, modules);
+
+        public static void InsertBeforeFirst<T>(this IModuleCollection moduleCollection, Predicate<T> filter, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.Insert(moduleCollection.GuardIndexOfFirst(filter), modules);
+
+        public static void InsertAfterFirst<T>(this IModuleCollection moduleCollection, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.InsertAfterFirst<T>(_ => true, modules);
+
+        public static void InsertAfterFirst<T>(this IModuleCollection moduleCollection, Predicate<T> filter, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.Insert(moduleCollection.GuardIndexOfFirst(filter) + 1, modules);
+
+        public static void InsertBeforeLast<T>(this IModuleCollection moduleCollection, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.InsertBeforeLast<T>(_ => true, modules);
+
+        public static void InsertBeforeLast<T>(this IModuleCollection moduleCollection, Predicate<T> filter, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.Insert(moduleCollection.GuardIndexOfLast(filter), modules);
+
+        public static void InsertAfterLast<T>(this IModuleCollection moduleCollection, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.InsertAfterLast<T>(_ => true, modules);
+
+        public static void InsertAfterLast<T>(this IModuleCollection moduleCollection, Predicate<T> filter, params IModule[] modules)
+            where T : class, IModule
+            => moduleCollection.Insert(moduleCollection.GuardIndexOfLast(filter) + 1, modules);
+
+        public static void ReplaceFirst<T>(this IModuleCollection moduleCollection, IModule module)
+            where T : class, IModule
+            => moduleCollection.ReplaceFirst<T>(_ => true, module);
+
+        public static void ReplaceFirst<T>(this IModuleCollection moduleCollection, Predicate<T> filter, IModule module)
+            where T : class, IModule
+            => moduleCollection.Replace(moduleCollection.GuardIndexOfFirst(filter), module);
+
+        public static void ReplaceLast<T>(this IModuleCollection moduleCollection, IModule module)
+            where T : class, IModule
+            => moduleCollection.ReplaceLast<T>(_ => true, module);
+
+        public static void ReplaceLast<T>(this IModuleCollection moduleCollection, Predicate<T> filter, IModule module)
+            where T : class, IModule
+            => moduleCollection.Replace(moduleCollection.GuardIndexOfLast(filter), module);
+
+        public static void Replace(this IModuleCollection moduleCollection, string name, IModule module)
+            => moduleCollection.Replace(moduleCollection.GuardIndexOf(name), module, name);
+
+        public static void Replace(this IModuleCollection moduleCollection, int index, IModule module, string name = "")
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                NamedModule namedModule = moduleCollection[index] as NamedModule;
+                if (namedModule != null)
+                {
+                    name = namedModule.Name;
+                }
+            }
+
+            moduleCollection.RemoveAt(index);
+            moduleCollection.Insert(index, name, module);
+        }
+        
+        private static int GuardIndexOfLast<T>(this IModuleCollection moduleCollection, Predicate<T> filter)
+            where T : class, IModule
+        {
+            for (int index = moduleCollection.Count - 1; index >= 0; index--)
+            {
+                IModule module = moduleCollection[index];
+                T expectedModule = module as T;
+                if (expectedModule == null)
+                {
+                    continue;
+                }
+
+                if (filter(expectedModule))
+                {
+                    return index;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find module of type {typeof(T).FullName}");
+        }
+
+        private static int GuardIndexOfFirst<T>(this IModuleCollection moduleCollection, Predicate<T> filter) where T : class, IModule
+        {
+            for (int index = 0; index < moduleCollection.Count; index++)
+            {
+                IModule module = moduleCollection[index];
+                T expectedModule = module as T;
+                if (expectedModule == null)
+                {
+                    continue;
+                }
+
+                if (filter(expectedModule))
+                {
+                    return index;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find module of type {typeof(T).FullName}");
+        }
+
+        private static int GuardIndexOf(this IModuleCollection moduleCollection, string name)
+        {
+            int index = moduleCollection.IndexOf(name);
+            if (index == -1)
+            {
+                throw new InvalidOperationException($"Could not find module with the name of {name}");
+            }
+
+            return index;
+        }
+    }
+}

--- a/src/core/Wyam.Common/Modules/ModuleCollection.cs
+++ b/src/core/Wyam.Common/Modules/ModuleCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Remoting;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -101,7 +102,7 @@ namespace Wyam.Common.Modules
                 {
                     return module;
                 }
-                throw new KeyNotFoundException();
+                throw new KeyNotFoundException($"The key \"{key}\" was not present in the dictionary.");
             }
         }
 
@@ -119,7 +120,7 @@ namespace Wyam.Common.Modules
 
         public void Insert(int index, params IModule[] modules)
         {
-            for (int i = index;; i++)
+            for (int i = index; i < index + modules.Length; i++)
             {
                 Insert(i, modules[i - index]);
             }
@@ -136,7 +137,7 @@ namespace Wyam.Common.Modules
             NamedModule namedModule = module as NamedModule;
             if (namedModule != null)
             {
-                if (checkNames && _modules.Any(x => x.Key.Equals(namedModule.Name)))
+                if (checkNames && _modules.Any(x => x.Key != null && x.Key.Equals(namedModule.Name)))
                 {
                     throw new ArgumentException($"A module with the name {namedModule.Name} already exists in the collection");
                 }

--- a/src/core/Wyam.Common/Wyam.Common.csproj
+++ b/src/core/Wyam.Common/Wyam.Common.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Configuration\IRecipe.cs" />
     <Compile Include="Modules\CollectionModule.cs" />
     <Compile Include="Modules\IModuleCollection.cs" />
+    <Compile Include="Modules\IModuleCollectionExtensions.cs" />
     <Compile Include="Modules\IReadOnlyModuleCollection.cs" />
     <Compile Include="Modules\ModuleCollection.cs" />
     <Compile Include="Modules\ModuleExtensions.cs" />

--- a/tests/core/Wyam.Core.Tests/Modules/Control/ModuleCollectionFixture.cs
+++ b/tests/core/Wyam.Core.Tests/Modules/Control/ModuleCollectionFixture.cs
@@ -4,7 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Wyam.Common.Execution;
+using Wyam.Common.Modules;
 using Wyam.Core.Execution;
+using Wyam.Core.Modules.Control;
+using Wyam.Core.Modules.IO;
 using Wyam.Testing;
 using Wyam.Testing.Modules;
 
@@ -49,7 +53,200 @@ namespace Wyam.Core.Tests.Modules.Control
                 Assert.AreEqual(6, b.OutputCount);
                 Assert.AreEqual(24, c.OutputCount);
             }
+        }
 
+        public class ModuleCollectionExtensionTests : BaseFixture
+        {
+            [Test]
+            public void InsertAfterFirst()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new ReadFiles(ctx => "*.md"),
+                    new WriteFiles()
+                });
+
+                collection.InsertAfterFirst<ReadFiles>(new CountModule("foo"));
+
+                Assert.AreEqual(collection[0].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[1].GetType(), typeof(CountModule));
+                Assert.AreEqual(collection[2].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[3].GetType(), typeof(WriteFiles));
+            }
+
+            [Test]
+            public void InsertBeforeFirst()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new ReadFiles(ctx => "*.md"),
+                    new WriteFiles()
+                });
+
+                collection.InsertBeforeFirst<ReadFiles>(new CountModule("foo"));
+
+                Assert.AreEqual(collection[0].GetType(), typeof(CountModule));
+                Assert.AreEqual(collection[1].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[2].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[3].GetType(), typeof(WriteFiles));
+            }
+
+
+            [Test]
+            public void InsertAfterLast()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new ReadFiles(ctx => "*.md"),
+                    new WriteFiles()
+                });
+
+                collection.InsertAfterLast<ReadFiles>(new CountModule("foo"));
+
+                Assert.AreEqual(collection[0].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[1].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[2].GetType(), typeof(CountModule));
+                Assert.AreEqual(collection[3].GetType(), typeof(WriteFiles));
+            }
+
+            [Test]
+            public void InsertBeforeLast()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new ReadFiles(ctx => "*.md"),
+                    new WriteFiles()
+                });
+
+                collection.InsertBeforeLast<ReadFiles>(new CountModule("foo"));
+
+                Assert.AreEqual(collection[0].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[1].GetType(), typeof(CountModule));
+                Assert.AreEqual(collection[2].GetType(), typeof(ReadFiles));
+                Assert.AreEqual(collection[3].GetType(), typeof(WriteFiles));
+            }
+
+            [Test]
+            public void ReplaceFirst()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new CountModule("mykey1"),
+                    new CountModule("mykey2"),
+                    new WriteFiles()
+                });
+
+                collection.ReplaceFirst<CountModule>(new CountModule("replacedKey"));
+
+                Assert.AreEqual("replacedKey", ((CountModule)collection[1]).ValueKey);
+                Assert.AreEqual("mykey2", ((CountModule)collection[2]).ValueKey);
+            }
+
+            [Test]
+            public void ReplaceLast()
+            {
+                IPipeline collection = new Pipeline("Test", new IModule[]
+                {
+                    new ReadFiles(ctx => "*.md"),
+                    new CountModule("mykey1"),
+                    new CountModule("mykey2"),
+                    new WriteFiles()
+                });
+
+                collection.ReplaceLast<CountModule>(new CountModule("replacedKey"));
+
+                Assert.AreEqual("mykey1", ((CountModule)collection[1]).ValueKey);
+                Assert.AreEqual("replacedKey", ((CountModule)collection[2]).ValueKey);
+            }
+
+            [Test]
+            public void InsertMultiple()
+            {
+                IPipeline collection = new Pipeline("Test", new[]
+                {
+                    new CountModule("mykey1").WithName("First"),
+                    new CountModule("mykey2").WithName("Second")
+                });
+
+                collection.InsertBefore("Second", new CountModule("mykey3"), new CountModule("mykey4"));
+
+                Assert.AreEqual("mykey1", ((CountModule)collection[0]).ValueKey);
+                Assert.AreEqual("mykey3", ((CountModule)collection[1]).ValueKey);
+                Assert.AreEqual("mykey4", ((CountModule)collection[2]).ValueKey);
+                Assert.AreEqual("mykey2", ((CountModule)collection[3]).ValueKey);
+            }
+
+            [Test]
+            public void InsertBeforeWithName()
+            {
+                IPipeline collection = new Pipeline("Test", new[]
+                {
+                    new CountModule("mykey1").WithName("First"),
+                    new CountModule("mykey2").WithName("Second")
+                });
+
+                collection.InsertBefore("Second", new CountModule("mykey3"));
+
+                Assert.AreEqual("mykey1", ((CountModule)collection[0]).ValueKey);
+                Assert.AreEqual("mykey3", ((CountModule)collection[1]).ValueKey);
+                Assert.AreEqual("mykey2", ((CountModule)collection[2]).ValueKey);
+            }
+
+            [Test]
+            public void InsertAfterWithName()
+            {
+                IPipeline collection = new Pipeline("Test", new[]
+                {
+                    new CountModule("mykey1").WithName("First"),
+                    new CountModule("mykey2").WithName("Second")
+                });
+
+                collection.InsertAfter("Second", new CountModule("mykey3"));
+
+                Assert.AreEqual("mykey1", ((CountModule)collection[0]).ValueKey);
+                Assert.AreEqual("mykey2", ((CountModule)collection[1]).ValueKey);
+                Assert.AreEqual("mykey3", ((CountModule)collection[2]).ValueKey);
+            }
+
+
+            [Test]
+            public void ReplaceWithName()
+            {
+                IPipeline collection = new Pipeline("Test", new[]
+                {
+                    new CountModule("mykey1").WithName("First"),
+                    new CountModule("mykey2").WithName("Second")
+                });
+
+                collection.Replace("Second", new CountModule("mykey3"));
+
+                Assert.AreEqual("mykey1", ((CountModule)collection[0]).ValueKey);
+                Assert.AreEqual("mykey3", ((CountModule)collection[1]).ValueKey);
+            }
+
+            [Test]
+            public void AlsoWorksWithModules()
+            {
+                IPipeline collection  = new Pipeline("Test", new []
+                {
+                    new CountModule("mykey1")
+                        .WithName("First"),
+                    new CountModule("mykey2")
+                        .WithName("Second"),
+                    new Concat(new CountModule("mysubkey1").WithName("inner"))
+                        .WithName("Third")
+                });
+
+                (collection["Third"] as IModuleCollection)
+                    .Replace("inner", new CountModule("newsubkey"));
+
+                Assert.AreEqual("newsubkey", ((CountModule) ((IModuleCollection) collection["Third"])["inner"]).ValueKey);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a handful of helpers for inserting new modules into an existing pipeline which should be very helpful for people needing to slightly tweak recipes. Goal is to be able to write code like this in the config.wyam file

```
Pipelines[BlogPipelines.Posts].InsertBeforeFirst<Razor>(new Highlight());
```

or 

```
Pipelines[BlogPipelines.Resources].ReplaceFirst<CopyFiles>(new CopyFiles("**/*{!.cshtml,!.md,!.scss,}"));
```

I had to stop myself from boiling the ocean with these methods though. A few scenarios that this won't cover would be

* Replacing the Title `Meta` module in the Tags pipeline. It's the second item in there. One thing that would help here is an overload that takes a predicate for additional filtering on each method, but that would double the size of everything. Wanted feedback before I spam that out.
* `Concat` modules. Jamming something into those isn't possible right now. If you had to, for example, tweak `ReadFiles("tags/index.cshtml")` in the Pages pipeline it would involve replacing the whole `Concat` module. 