### PR TITLE
Moves Preview Server to Use Kestrel

### DIFF
--- a/src/clients/Wyam/App.config
+++ b/src/clients/Wyam/App.config
@@ -81,6 +81,18 @@
         <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/clients/Wyam/Owin/IApplicationBuilderExtensions.cs
+++ b/src/clients/Wyam/Owin/IApplicationBuilderExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Owin.Builder;
+
+using Owin;
+
+namespace Wyam.Owin
+{
+    internal static class ApplicationBuilderExtensions
+    {
+        // http://stackoverflow.com/a/30742029/2001966
+
+        public static void UseOwinBuilder(this IApplicationBuilder app, Action<IAppBuilder> owinConfiguration)
+        {
+            app.UseOwin(
+                addToPipeline =>
+                {
+                    addToPipeline(
+                        next =>
+                        {
+                            AppBuilder builder = new AppBuilder();
+                            owinConfiguration(builder);
+                            builder.Run(ctx => next(ctx.Environment));
+
+                            // ReSharper disable once SuggestVarOrType_Elsewhere
+                            var appFunc = (Func<IDictionary<string, object>, Task>) builder.Build(typeof(Func<IDictionary<string, object>, Task>));
+
+                            return appFunc;
+                        });
+                });
+        }
+    }
+}

--- a/src/clients/Wyam/PreviewServer.cs
+++ b/src/clients/Wyam/PreviewServer.cs
@@ -4,7 +4,6 @@ using System.IO;
 
 using Microsoft.Owin;
 using Microsoft.Owin.FileSystems;
-using Microsoft.Owin.Hosting;
 using Microsoft.Owin.Hosting.Tracing;
 using Microsoft.Owin.StaticFiles;
 
@@ -13,6 +12,7 @@ using Owin;
 using Wyam.Common.IO;
 using Wyam.Common.Tracing;
 using Wyam.Owin;
+using Wyam.Server;
 
 namespace Wyam
 {
@@ -20,16 +20,11 @@ namespace Wyam
     {
         public static IDisposable Start(DirectoryPath path, int port, bool forceExtension, DirectoryPath virtualDirectory)
         {
-            IDisposable server;
+            HttpServer server;
             try
             {
-                StartOptions options = new StartOptions("http://localhost:" + port);
-
-                // Disable built-in owin tracing by using a null trace output
-                // http://stackoverflow.com/questions/17948363/tracelistener-in-owin-self-hosting
-                options.Settings.Add(typeof(ITraceOutputFactory).FullName, typeof(NullTraceOutputFactory).AssemblyQualifiedName);
-
-                server = WebApp.Start(options, app => ConfigureOwin(app, path.Name, forceExtension, virtualDirectory));
+                server = new HttpServer();
+                server.StartServer(port, app => ConfigureOwin(app, path, forceExtension, virtualDirectory));
             }
             catch (Exception ex)
             {

--- a/src/clients/Wyam/PreviewServer.cs
+++ b/src/clients/Wyam/PreviewServer.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 using Microsoft.Owin;
 using Microsoft.Owin.FileSystems;
-using Microsoft.Owin.Hosting.Tracing;
 using Microsoft.Owin.StaticFiles;
 
 using Owin;
@@ -78,14 +76,6 @@ namespace Wyam
                 FileSystem = outputFolder,
                 ServeUnknownFileTypes = true
             });
-        }
-
-        private class NullTraceOutputFactory : ITraceOutputFactory
-        {
-            public TextWriter Create(string outputFile)
-            {
-                return StreamWriter.Null;
-            }
         }
     }
 }

--- a/src/clients/Wyam/PreviewServer.cs
+++ b/src/clients/Wyam/PreviewServer.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+
 using Microsoft.Owin;
 using Microsoft.Owin.FileSystems;
 using Microsoft.Owin.Hosting;
 using Microsoft.Owin.Hosting.Tracing;
 using Microsoft.Owin.StaticFiles;
+
 using Owin;
+
 using Wyam.Common.IO;
 using Wyam.Common.Tracing;
 using Wyam.Owin;
@@ -26,48 +29,7 @@ namespace Wyam
                 // http://stackoverflow.com/questions/17948363/tracelistener-in-owin-self-hosting
                 options.Settings.Add(typeof(ITraceOutputFactory).FullName, typeof(NullTraceOutputFactory).AssemblyQualifiedName);
 
-                server = WebApp.Start(options, app =>
-                {
-                    Microsoft.Owin.FileSystems.IFileSystem outputFolder = new PhysicalFileSystem(path.FullPath);
-
-                    // Support for virtual directory
-                    if (virtualDirectory != null)
-                    {
-                        app.UseVirtualDirectory(virtualDirectory.FullPath);
-                    }
-
-                    // Disable caching
-                    app.Use((c, t) =>
-                    {
-                        c.Response.Headers.Append("Cache-Control", "no-cache, no-store, must-revalidate");
-                        c.Response.Headers.Append("Pragma", "no-cache");
-                        c.Response.Headers.Append("Expires", "0");
-                        return t();
-                    });
-
-                    // Support for extensionless URLs
-                    if (!forceExtension)
-                    {
-                        app.UseExtensionlessUrls(new ExtensionlessUrlsOptions
-                        {
-                            FileSystem = outputFolder
-                        });
-                    }
-
-                    // Serve up all static files
-                    app.UseDefaultFiles(new DefaultFilesOptions
-                    {
-                        RequestPath = PathString.Empty,
-                        FileSystem = outputFolder,
-                        DefaultFileNames = new List<string> { "index.html", "index.htm", "home.html", "home.htm", "default.html", "default.html" }
-                    });
-                    app.UseStaticFiles(new StaticFileOptions
-                    {
-                        RequestPath = PathString.Empty,
-                        FileSystem = outputFolder,
-                        ServeUnknownFileTypes = true
-                    });
-                });
+                server = WebApp.Start(options, app => ConfigureOwin(app, path.Name, forceExtension, virtualDirectory));
             }
             catch (Exception ex)
             {
@@ -76,8 +38,51 @@ namespace Wyam
             }
 
             Trace.Information($"Preview server listening on port {port} and serving from path {path}"
-                + (virtualDirectory == null ? string.Empty : $" with virtual directory {virtualDirectory.FullPath}"));
+                              + (virtualDirectory == null ? string.Empty : $" with virtual directory {virtualDirectory.FullPath}"));
             return server;
+        }
+
+        internal static void ConfigureOwin(IAppBuilder app, DirectoryPath path, bool forceExtension, DirectoryPath virtualDirectory)
+        {
+            Microsoft.Owin.FileSystems.IFileSystem outputFolder = new PhysicalFileSystem(path.FullPath);
+
+            // Support for virtual directory
+            if (virtualDirectory != null)
+            {
+                app.UseVirtualDirectory(virtualDirectory.FullPath);
+            }
+
+            // Disable caching
+            app.Use((c, t) =>
+            {
+                c.Response.Headers.Append("Cache-Control", "no-cache, no-store, must-revalidate");
+                c.Response.Headers.Append("Pragma", "no-cache");
+                c.Response.Headers.Append("Expires", "0");
+                return t();
+            });
+
+            // Support for extensionless URLs
+            if (!forceExtension)
+            {
+                app.UseExtensionlessUrls(new ExtensionlessUrlsOptions
+                {
+                    FileSystem = outputFolder
+                });
+            }
+
+            // Serve up all static files
+            app.UseDefaultFiles(new DefaultFilesOptions
+            {
+                RequestPath = PathString.Empty,
+                FileSystem = outputFolder,
+                DefaultFileNames = new List<string> {"index.html", "index.htm", "home.html", "home.htm", "default.html", "default.html"}
+            });
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                RequestPath = PathString.Empty,
+                FileSystem = outputFolder,
+                ServeUnknownFileTypes = true
+            });
         }
 
         private class NullTraceOutputFactory : ITraceOutputFactory

--- a/src/clients/Wyam/Program.cs
+++ b/src/clients/Wyam/Program.cs
@@ -8,8 +8,6 @@ using System.Reflection;
 using System.Threading;
 using Microsoft.Owin;
 using Microsoft.Owin.FileSystems;
-using Microsoft.Owin.Hosting;
-using Microsoft.Owin.Hosting.Tracing;
 using Microsoft.Owin.StaticFiles;
 using Owin;
 using Wyam.Commands;
@@ -45,7 +43,7 @@ namespace Wyam
         private int Run(string[] args)
         {
             // Add a default trace listener
-            Trace.AddListener(new SimpleColorConsoleTraceListener { TraceOutputOptions = System.Diagnostics.TraceOptions.None });
+            Trace.AddListener(new SimpleColorConsoleTraceListener { TraceOutputOptions = TraceOptions.None });
             
             // Output version info
             Trace.Information($"Wyam version {Engine.Version}");

--- a/src/clients/Wyam/Server/ApplicationBuilderExtensions.cs
+++ b/src/clients/Wyam/Server/ApplicationBuilderExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Owin.Builder;
 
 using Owin;
 
-namespace Wyam.Owin
+namespace Wyam.Server
 {
     internal static class ApplicationBuilderExtensions
     {

--- a/src/clients/Wyam/Server/HttpServer.cs
+++ b/src/clients/Wyam/Server/HttpServer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+using Owin;
+
+using Wyam.Owin;
+
+namespace Wyam.Server
+{
+    internal class HttpServer : IDisposable
+    {
+        private IWebHost _host;
+
+        public void StartServer(int port, Action<IAppBuilder> owinConfiguration)
+        {
+            _host = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls($"http://localhost:{port}")
+                .Configure(builder =>
+                {
+                    // Enable websocket support
+                    builder.UseWebSockets();
+
+                    // Support drop-in replacement
+                    builder.UseOwinBuilder(owinConfiguration);
+                })
+                .Build();
+            _host.Start();
+        }
+
+        public void Dispose()
+        {
+            _host?.Dispose();
+        }
+    }
+}

--- a/src/clients/Wyam/Server/HttpServer.cs
+++ b/src/clients/Wyam/Server/HttpServer.cs
@@ -5,8 +5,6 @@ using Microsoft.AspNetCore.Hosting;
 
 using Owin;
 
-using Wyam.Owin;
-
 namespace Wyam.Server
 {
     internal class HttpServer : IDisposable

--- a/src/clients/Wyam/Wyam.csproj
+++ b/src/clients/Wyam/Wyam.csproj
@@ -268,7 +268,7 @@
     <Compile Include="Commands\ConfigOptions.cs" />
     <Compile Include="Commands\HelpCommand.cs" />
     <Compile Include="Commands\PreviewCommand.cs" />
-    <Compile Include="Owin\IApplicationBuilderExtensions.cs" />
+    <Compile Include="Server\ApplicationBuilderExtensions.cs" />
     <Compile Include="Owin\VirtualDirectoryExtensions.cs" />
     <Compile Include="Owin\VirtualDirectoryMiddleware.cs" />
     <Compile Include="PreviewServer.cs" />
@@ -296,7 +296,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-	<!-- HACK, required until VS2017 and the new project structure. -->
+    <!-- HACK, required until VS2017 and the new project structure. -->
     <Content Include="..\..\..\packages\Libuv.1.9.1\runtimes\win7-x86\native\libuv.dll">
       <Link>libuv.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/clients/Wyam/Wyam.csproj
+++ b/src/clients/Wyam/Wyam.csproj
@@ -49,6 +49,84 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Hosting, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Hosting.1.1.0\lib\net451\Microsoft.AspNetCore.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Hosting.Abstractions.1.1.0\lib\net451\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.1.1.0\lib\net451\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Http.1.1.0\lib\net451\Microsoft.AspNetCore.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Http.Abstractions.1.1.0\lib\net451\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Http.Extensions.1.1.0\lib\net451\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Http.Features.1.1.0\lib\net451\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Owin, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Owin.1.1.0\lib\net451\Microsoft.AspNetCore.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.Server.Kestrel.1.1.0\lib\net451\Microsoft.AspNetCore.Server.Kestrel.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebSockets, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.WebSockets.1.0.0\lib\net451\Microsoft.AspNetCore.WebSockets.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNetCore.WebUtilities.1.1.0\lib\net451\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Configuration.1.1.0\lib\netstandard1.1\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Configuration.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.1.1.0\lib\net451\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.1.1.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.FileProviders.Physical.1.1.0\lib\net451\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.FileSystemGlobbing.1.1.0\lib\net45\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.1.1.0\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.ObjectPool.1.1.0\lib\net451\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Options.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.PlatformAbstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.PlatformAbstractions.1.1.0\lib\net451\Microsoft.Extensions.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Net.Http.Headers.1.1.0\lib\netstandard1.1\Microsoft.Net.Http.Headers.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -69,11 +147,20 @@
       <HintPath>..\..\..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Collections.Immutable.1.3.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
@@ -88,23 +175,91 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Numerics.Vectors.4.3.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Reflection.Metadata.1.4.1\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.3.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.InteropServices.4.3.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Text.Encodings.Web.4.3.0\lib\netstandard1.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionFileSystemWatcher.cs" />
@@ -113,6 +268,7 @@
     <Compile Include="Commands\ConfigOptions.cs" />
     <Compile Include="Commands\HelpCommand.cs" />
     <Compile Include="Commands\PreviewCommand.cs" />
+    <Compile Include="Owin\IApplicationBuilderExtensions.cs" />
     <Compile Include="Owin\VirtualDirectoryExtensions.cs" />
     <Compile Include="Owin\VirtualDirectoryMiddleware.cs" />
     <Compile Include="PreviewServer.cs" />
@@ -130,6 +286,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Commands\CommandParser.cs" />
+    <Compile Include="Server\HttpServer.cs" />
     <Compile Include="SimpleColorConsoleTraceListener.cs" />
     <Compile Include="SimpleFileTraceListener.cs" />
     <Compile Include="StandardInputReader.cs" />
@@ -137,6 +294,14 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+	<!-- HACK, required until VS2017 and the new project structure. -->
+    <Content Include="..\..\..\packages\Libuv.1.9.1\runtimes\win7-x86\native\libuv.dll">
+      <Link>libuv.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Wyam.Configuration\Wyam.Configuration.csproj">

--- a/src/clients/Wyam/Wyam.csproj
+++ b/src/clients/Wyam/Wyam.csproj
@@ -135,14 +135,6 @@
       <HintPath>..\..\..\packages\Microsoft.Owin.FileSystems.3.0.1\lib\net45\Microsoft.Owin.FileSystems.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Owin.StaticFiles, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
       <Private>True</Private>

--- a/src/clients/Wyam/packages.config
+++ b/src/clients/Wyam/packages.config
@@ -1,20 +1,91 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Libuv" version="1.9.1" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Hosting" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Http" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Owin" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.WebSockets" version="1.0.0" targetFramework="net462" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Configuration" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.ObjectPool" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Options" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.PlatformAbstractions" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.Net.Http.Headers" version="1.1.0" targetFramework="net462" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.3.0" targetFramework="net46" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.3.0" targetFramework="net462" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Metadata" version="1.4.1" targetFramework="net462" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
 </packages>

--- a/src/clients/Wyam/packages.config
+++ b/src/clients/Wyam/packages.config
@@ -30,8 +30,6 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net45" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />

--- a/tests/clients/Wyam.Tests/app.config
+++ b/tests/clients/Wyam.Tests/app.config
@@ -62,6 +62,18 @@
         <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/tests/integration/Wyam.Examples.Tests/app.config
+++ b/tests/integration/Wyam.Examples.Tests/app.config
@@ -90,6 +90,18 @@
         <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>


### PR DESCRIPTION
This pull request adds support for the Kestrel server.

> Kestrel is a cross-platform web server for ASP.NET Core based on libuv, a cross-platform asynchronous I/O library. Kestrel is the web server that is included by default in ASP.NET Core new project templates.

The move was easier than expected, most of the changes are the new packages, the preview server is virtually the same. 

A basic pro/cons list (some are IMHO):

## Gains

- Trivial support for HTTPS.
- Cross platform.
- No longer uses http.sys.
  - No more issues with url reservations under Windows (I have very strong feelings for `urlacl` 😒).
  - Not hostname verification.
- Kestrel will replace Katana.
- Easier support for dotNetCore.
- WebSockets! <- makes #420 a bit more possible.

## Losses

- No longer uses http.sys.
- No support for port sharing with IIS (did anyone use this anyway?)
- Complicated short term support:
  - Native nuget packages are not supported out-of-box < VS2017 projects (custom includes required). This is mitigated by a move to dotNetCore (planned?).
  - Only supports Windows x86 with the default build. This is also mitigated by either upgrading to VS2017 or dotNetCore.

## Considerations

- Large functional move with little benefit in the majority of cases. I'm primarily concerned with what is unknown with Kestrel - not much community usage yet + not much personal experience.
- Reduces portability for now, but Wyam doesn't support Mono anyway, so moot?