### PR TITLE
Filters JetBrains assembly from loaded namespace list while profiling

### DIFF
--- a/src/core/Wyam.Configuration/Configurator.cs
+++ b/src/core/Wyam.Configuration/Configurator.cs
@@ -254,8 +254,11 @@ namespace Wyam.Configuration
         private void AddNamespaces()
         {
             // Add all Wyam.Common namespaces
+            // the JetBrains.Profiler filter is needed due to DotTrace dynamically
+            // adding a reference to that assembly when running under its profiler. We want
+            // to exclude it.
             _engine.Namespaces.AddRange(typeof(IModule).Assembly.GetTypes()
-                .Where(x => !string.IsNullOrWhiteSpace(x.Namespace))
+                .Where(x => !string.IsNullOrWhiteSpace(x.Namespace) && !x.Namespace.StartsWith("JetBrains.Profiler"))
                 .Select(x => x.Namespace)
                 .Distinct());
 


### PR DESCRIPTION
While looking at perf I ran into a weird issue where DotTrace caused the configuration and razor modules to blow up. Turns out that DotTrace shoves it's profiling assembly in dynamically when running a profile of the application. Not a huge deal but it gets picked up as a loaded namespace but the tools that write the configuration file using statements and with the razor parser. If fails to find that DLL and fails. 

This simply filters it out if found from the config.