### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/clients/Cake.Wyam/Cake.Wyam.csproj
+++ b/src/clients/Cake.Wyam/Cake.Wyam.csproj
@@ -33,12 +33,12 @@
     <DocumentationFile>bin\Release\Cake.Wyam.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Cake.Common.0.10.1\lib\net45\Cake.Common.dll</HintPath>
+    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/clients/Cake.Wyam/packages.config
+++ b/src/clients/Cake.Wyam/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.10.1" targetFramework="net452" developmentDependency="true" />
-  <package id="Cake.Core" version="0.10.1" targetFramework="net452" developmentDependency="true" />
+  <package id="Cake.Common" version="0.17.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.

Fixes #437