### PR TITLE
Resolves 500 Error w/ LR Injection

### DIFF
--- a/tests/core/Wyam.Hosting.Tests/Owin/Documents/BasicHtmlDocumentNoBodyEnd.html
+++ b/tests/core/Wyam.Hosting.Tests/Owin/Documents/BasicHtmlDocumentNoBodyEnd.html
@@ -1,0 +1,8 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8"/>
+    <title></title>
+</head>
+<body>

--- a/tests/core/Wyam.Hosting.Tests/Owin/ScriptInjectionMiddlewareTests.cs
+++ b/tests/core/Wyam.Hosting.Tests/Owin/ScriptInjectionMiddlewareTests.cs
@@ -55,6 +55,17 @@ namespace Wyam.Hosting.Tests.Owin
             Assert.AreEqual(expected, body);
         }
 
+        [Test]
+        public async Task WhenServingHtmlWithoutBodyDoNotModify()
+        {
+            const string filename = "BasicHtmlDocumentNoBodyEnd.html";
+            HttpResponseMessage response = await _host.CreateRequest(filename).GetAsync();
+            string body = await response.Content.ReadAsStringAsync();
+
+            string expected = ReadFile(filename);
+            Assert.AreEqual(expected, body);
+        }
+
         private string ReadFile(string filename)
         {
             string resourceName = $"{ContentNamespace}.{filename}";

--- a/tests/core/Wyam.Hosting.Tests/Wyam.Hosting.Tests.csproj
+++ b/tests/core/Wyam.Hosting.Tests/Wyam.Hosting.Tests.csproj
@@ -352,6 +352,9 @@
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Owin\Documents\BasicHtmlDocumentNoBodyEnd.html" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Found a bug in the LiveReload injection middleware, I've added a test case to show it. It presents as 500 errors on any HTML page that does not have a ending body tag.

The variable `interceptedBody` is closed by the `using` statement on `reader` resulting in an `ObjectDisposedException`. Removed usage of the `using` statement to prevent early closure (recommend for IDisposables, not strictly required for MemoryStreams).

## Considerations

Sooo, it turns out the HTML minifier included with Wyam actually correctly removes the ending `html`/`body` tags (took me a while to figure it out). According to (https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#optional-tags)

> A body element's end tag may be omitted if the body element is not immediately followed by a comment.

