### PR TITLE
WIP: Caching Module(s)

### DIFF
--- a/src/core/Wyam.Core/Modules/Control/SerialCache.cs
+++ b/src/core/Wyam.Core/Modules/Control/SerialCache.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+
+using Wyam.Common.Documents;
+using Wyam.Common.Execution;
+using Wyam.Common.IO;
+using Wyam.Common.Meta;
+using Wyam.Common.Modules;
+
+namespace Wyam.Core.Modules.Control
+{
+    /// <summary>
+    /// TODO Write this
+    /// </summary>
+    public class SerialCache : ContainerModule
+    {
+        // Considerations
+        // - This module assumes a single input/multiple outputs
+        // - Should we cache selectively?
+        // TO.DO
+        // Consider cacheability based on metadata and source path, not just content.
+
+        // TODO Move this to key object
+        private const string InputHashKey = "SerialCache.InputHash";
+        private const string FromCacheKey = "SerialCache.FromCache";
+
+        private readonly ConcurrentDictionary<string, IList<CachedDocument>> _cachePerHash = new ConcurrentDictionary<string, IList<CachedDocument>>();
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="modules">Text</param>
+        public SerialCache(params IModule[] modules)
+            : base(modules)
+        {
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+        {
+            return inputs.SelectMany(x => ExecuteAndCache(x, context));
+        }
+
+        private IEnumerable<IDocument> ExecuteAndCache(IDocument input, IExecutionContext context)
+        {
+            // Get the current hash of the input document
+            string hashKey = GetHash(input);
+            bool fromCache = true;
+
+            // Prep an execution for a lazy run if document is not cached
+            Func<IList<CachedDocument>> lazyExecute = () =>
+            {
+                fromCache = false;
+                IEnumerable<IDocument> inputs = ToSingleEnumerable(input);
+
+                List<IDocument> outputs = context.Execute(this, inputs).ToList();
+                return outputs.Select(CachedDocument.Create).ToList();
+            };
+            IList<CachedDocument> result = _cachePerHash.GetOrAdd(hashKey, s => lazyExecute());
+
+            // Added possibly helpful metadata.
+            var extaMetaData = new Dictionary<string, object>
+            {
+                {InputHashKey, hashKey},
+                {FromCacheKey, fromCache}
+            };
+            foreach (CachedDocument output in result)
+            {
+                yield return context.GetDocument(output.FileSource, new MemoryStream(output.Content), output.MetaData.Concat(extaMetaData));
+            }
+        }
+
+        private string GetHash(IDocument input)
+        {
+            using (Stream contentStream = input.GetStream())
+            {
+                // TODO Conisder other keys to use
+                string hash = GetHashKey("key", contentStream);
+                return hash;
+            }
+        }
+
+        private static IEnumerable<T> ToSingleEnumerable<T>(T input)
+        {
+            yield return input;
+        }
+
+        private static string GetHashKey(string key, Stream stream)
+        {
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] hashedBytes = md5.ComputeHash(stream);
+                return key + BitConverter.ToString(md5.ComputeHash(hashedBytes));
+            }
+        }
+
+        private class CachedDocument
+        {
+            public FilePath FileSource { get; private set; }
+
+            public byte[] Content { get; private set; }
+
+            public IMetadata MetaData { get; private set; }
+
+            public static CachedDocument Create(IDocument document)
+            {
+                using (Stream stream = document.GetStream())
+                {
+                    MemoryStream memory = new MemoryStream();
+                    stream.CopyTo(memory);
+                    return new CachedDocument
+                    {
+                        Content = memory.ToArray(),
+                        FileSource = document.Source,
+                        MetaData = document.Metadata
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/core/Wyam.Core/Wyam.Core.csproj
+++ b/src/core/Wyam.Core/Wyam.Core.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Modules\Contents\Join.cs" />
     <Compile Include="Modules\Contents\JoinedMetadata.cs" />
     <Compile Include="Modules\Contents\Redirect.cs" />
+    <Compile Include="Modules\Control\SerialCache.cs" />
     <Compile Include="Modules\IO\Include.cs" />
     <Compile Include="Modules\Control\Combine.cs" />
     <Compile Include="Modules\Contents\SitemapItem.cs" />

--- a/src/core/Wyam.Testing/ExecutionHelper.cs
+++ b/src/core/Wyam.Testing/ExecutionHelper.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Wyam.Testing
+{
+    /// <summary>
+    /// Execution Helpers
+    /// </summary>
+    public static class ExecutionHelper
+    {
+        /// <summary>
+        /// Enumerate a enumerable.
+        /// </summary>
+        /// <param name="enumerable">The enumerable to enumerate.</param>
+        /// <typeparam name="T">Generic type of the enumerable.</typeparam>
+        public static void Enumerate<T>(this IEnumerable<T> enumerable)
+        {
+            // ReSharper disable once UnusedVariable
+            foreach (T nothing in enumerable)
+            {
+            }
+        }
+    }
+}

--- a/src/core/Wyam.Testing/Wyam.Testing.csproj
+++ b/src/core/Wyam.Testing/Wyam.Testing.csproj
@@ -138,6 +138,7 @@
     </Compile>
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Documents\TestDocument.cs" />
+    <Compile Include="ExecutionHelper.cs" />
     <Compile Include="Execution\TestExecutionContext.cs" />
     <Compile Include="Modules\CountModule.cs" />
     <Compile Include="IO\StringBuilderStream.cs" />

--- a/tests/core/Wyam.Core.Tests/Modules/Control/SerialCacheFixture.cs
+++ b/tests/core/Wyam.Core.Tests/Modules/Control/SerialCacheFixture.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using NUnit.Framework;
+
+using Ploeh.AutoFixture;
+
+using Wyam.Common.Documents;
+using Wyam.Common.Execution;
+using Wyam.Common.Modules;
+using Wyam.Core.Modules.Control;
+using Wyam.Testing;
+using Wyam.Testing.Documents;
+using Wyam.Testing.Execution;
+
+namespace Wyam.Core.Tests.Modules.Control
+{
+    public class SerialCacheFixture : BaseFixture
+    {
+        public class ExecuteTests : SerialCacheFixture
+        {
+            private static readonly Fixture Autofixture = new Fixture();
+
+            [Test]
+            public void During_first_run_passthrough_all_outputs()
+            {
+                // Given
+                TestExecutionContext context = new TestExecutionContext();
+                CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
+                IDocument input = new TestDocument(Autofixture.Create<string>());
+
+                SerialCache combine = new SerialCache(appender);
+
+                // When
+                IDocument result = combine.Execute(new[] {input}, context).Single();
+
+                // Then
+                CollectionAssert.AreEqual(input.Content + appender.Text, result.Content);
+            }
+
+            [Test]
+            public void During_cached_pass_use_exiting_outputs()
+            {
+                // Given
+                TestExecutionContext context = new TestExecutionContext();
+                CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
+                IDocument input = new TestDocument(Autofixture.Create<string>());
+
+                SerialCache combine = new SerialCache(appender);
+                combine.Execute(new[] { input }, context).Enumerate();
+
+                // When
+                IDocument result = combine.Execute(new[] { input }, context).Single();
+
+                // Then
+                CollectionAssert.AreEqual(input.Content + appender.Text, result.Content);
+            }
+
+            [Test]
+            public void During_cached_pass_do_not_re_execute()
+            {
+                // Given
+                TestExecutionContext context = new TestExecutionContext();
+                CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
+                IDocument input = new TestDocument(Autofixture.Create<string>());
+
+                SerialCache combine = new SerialCache(appender);
+                combine.Execute(new[] { input }, context).Enumerate();
+
+                // When
+                combine.Execute(new[] { input }, context).Enumerate();
+
+                // Then
+                Assert.AreEqual(1, appender.ExecuteCount);
+            }
+        }
+
+        private class CacheTesterModule : IModule
+        {
+            public string Text { get; }
+
+            public int ExecuteCount { get; private set; }
+
+            public CacheTesterModule(string text)
+            {
+                Text = text;
+            }
+
+            public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
+            {
+                ExecuteCount++;
+                foreach (IDocument document in inputs)
+                {
+                    yield return context.GetDocument(document, document.Content + Text);
+                }
+            }
+        }
+    }
+}

--- a/tests/core/Wyam.Core.Tests/Modules/Control/SerialCacheFixture.cs
+++ b/tests/core/Wyam.Core.Tests/Modules/Control/SerialCacheFixture.cs
@@ -29,10 +29,10 @@ namespace Wyam.Core.Tests.Modules.Control
                 CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
                 IDocument input = new TestDocument(Autofixture.Create<string>());
 
-                SerialCache combine = new SerialCache(appender);
+                SerialCache cache = new SerialCache(appender);
 
                 // When
-                IDocument result = combine.Execute(new[] {input}, context).Single();
+                IDocument result = cache.Execute(new[] {input}, context).Single();
 
                 // Then
                 CollectionAssert.AreEqual(input.Content + appender.Text, result.Content);
@@ -46,11 +46,11 @@ namespace Wyam.Core.Tests.Modules.Control
                 CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
                 IDocument input = new TestDocument(Autofixture.Create<string>());
 
-                SerialCache combine = new SerialCache(appender);
-                combine.Execute(new[] { input }, context).Enumerate();
+                SerialCache cache = new SerialCache(appender);
+                cache.Execute(new[] { input }, context).Enumerate();
 
                 // When
-                IDocument result = combine.Execute(new[] { input }, context).Single();
+                IDocument result = cache.Execute(new[] { input }, context).Single();
 
                 // Then
                 CollectionAssert.AreEqual(input.Content + appender.Text, result.Content);
@@ -64,11 +64,11 @@ namespace Wyam.Core.Tests.Modules.Control
                 CacheTesterModule appender = Autofixture.Create<CacheTesterModule>();
                 IDocument input = new TestDocument(Autofixture.Create<string>());
 
-                SerialCache combine = new SerialCache(appender);
-                combine.Execute(new[] { input }, context).Enumerate();
+                SerialCache cache = new SerialCache(appender);
+                cache.Execute(new[] { input }, context).Enumerate();
 
                 // When
-                combine.Execute(new[] { input }, context).Enumerate();
+                cache.Execute(new[] { input }, context).Enumerate();
 
                 // Then
                 Assert.AreEqual(1, appender.ExecuteCount);

--- a/tests/core/Wyam.Core.Tests/Wyam.Core.Tests.csproj
+++ b/tests/core/Wyam.Core.Tests/Wyam.Core.Tests.csproj
@@ -47,6 +47,9 @@
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AutoFixture.3.50.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
@@ -137,6 +140,7 @@
     <Compile Include="IO\VirtualInputDirectoryFixture.cs" />
     <Compile Include="Modules\Contents\JoinFixture.cs" />
     <Compile Include="Modules\Contents\RedirectFixture.cs" />
+    <Compile Include="Modules\Control\SerialCacheFixture.cs" />
     <Compile Include="Modules\Control\CombineFixture.cs" />
     <Compile Include="Modules\Control\ConcatBranchFixture.cs" />
     <Compile Include="Execution\EngineTests.cs" />

--- a/tests/core/Wyam.Core.Tests/packages.config
+++ b/tests/core/Wyam.Core.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoFixture" version="3.50.2" targetFramework="net462" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />

--- a/tests/core/Wyam.Hosting.Tests/Wyam.Hosting.Tests.csproj
+++ b/tests/core/Wyam.Hosting.Tests/Wyam.Hosting.Tests.csproj
@@ -333,6 +333,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Owin\Documents\BasicHtmlDocumentNoBodyEnd.html" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/tests/extensions/Wyam.Highlight.Tests/Wyam.Highlight.Tests.csproj
+++ b/tests/extensions/Wyam.Highlight.Tests/Wyam.Highlight.Tests.csproj
@@ -158,6 +158,9 @@
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This pull request attempts to resolve #346 and focuses primarily on quality of life speed improvements when using the preview server.

## Considerations

Wyam's greatest strength (IMHO) is its flexibility with its pipelines. This, however, makes caching an incredibly difficult problem to solve. To mitigate this somewhat I propose targeted caching modules, rather than attempting to compensate for every edge case.

## Module(s) (pending a better name)

- [ ] SerialCache - This module takes in a stream of inputs and considers each individually for caching. These inputs may output one or many outputs which are cached under the input. When the input is seen again without modifications, the outputs are simply returned. Currently CRC32 hashing is occurring on the document content with the cache being stored on the disk. This caching module assumes that each input can be handled independently without side effect.

```
engine.Pipelines.Add(PipelineKeys.Pages,
    new ReadFiles(ctx => "*.md"),
    new SerialCache(
        new FrontMatter(new Yaml.Yaml()),
        new Execute(ctx => new Markdown.Markdown()),
        new Razor.Razor(),
        new MinifyHtml()
    ),
    new WriteFiles()
);
```


## Notes

- I'm currently seeing 3x speed improvement on my blog.
- I will fix Unit Test naming.
- Still a lot of work to do, but want to open for feedback early.
- First module, hope I'm not doing something blatantly bad. 😸 