### PR TITLE
Reuse the same ASP.net objects to avoid compiling the same pages agai…

### DIFF
--- a/src/extensions/Wyam.Razor/DynamicAssemblyCollection.cs
+++ b/src/extensions/Wyam.Razor/DynamicAssemblyCollection.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wyam.Razor
+{
+    internal class DynamicAssemblyCollection : IEnumerable<byte[]>
+    {
+        private readonly IReadOnlyCollection<byte[]> _assemblies;
+
+        public DynamicAssemblyCollection(IEnumerable<byte[]> assemblies)
+        {
+            _assemblies = assemblies.ToArray();
+        }
+
+        public IEnumerator<byte[]> GetEnumerator()
+        {
+            IEnumerable<byte[]> assemblies = _assemblies;
+            return assemblies.GetEnumerator();
+        }
+
+        public override int GetHashCode()
+        {
+            return _assemblies.Count;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as DynamicAssemblyCollection;
+            return other != null && _assemblies.SequenceEqual(other._assemblies);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/extensions/Wyam.Razor/HostingEnvironment.cs
+++ b/src/extensions/Wyam.Razor/HostingEnvironment.cs
@@ -1,21 +1,22 @@
 ﻿using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.FileProviders;
 using Wyam.Common.Execution;
+using Wyam.Common.IO;
+using IFileProvider = Microsoft.Extensions.FileProviders.IFileProvider;
 
 namespace Wyam.Razor
 {
     internal class HostingEnvironment : IHostingEnvironment
     {
-        public HostingEnvironment(IExecutionContext context)
+        public HostingEnvironment(IReadOnlyFileSystem fileSystem)
         {
             EnvironmentName = "Wyam";
 
             // This gets used to load dependencies and is passed to Assembly.Load()
             ApplicationName = typeof(HostingEnvironment).Assembly.FullName;
 
-            WebRootPath = context.FileSystem.RootPath.FullPath;
-            WebRootFileProvider = new FileSystemFileProvider(context.FileSystem);
+            WebRootPath = fileSystem.RootPath.FullPath;
+            WebRootFileProvider = new FileSystemFileProvider(fileSystem);
             ContentRootPath = WebRootPath;
             ContentRootFileProvider = WebRootFileProvider;
         }

--- a/src/extensions/Wyam.Razor/MetadataReferenceFeatureProvider.cs
+++ b/src/extensions/Wyam.Razor/MetadataReferenceFeatureProvider.cs
@@ -5,17 +5,16 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.CodeAnalysis;
-using Wyam.Common.Execution;
 
 namespace Wyam.Razor
 {
     internal class MetadataReferenceFeatureProvider : IApplicationFeatureProvider<MetadataReferenceFeature>
     {
-        private readonly IExecutionContext _executionContext;
+        private readonly DynamicAssemblyCollection _dynamicAssemblies;
 
-        public MetadataReferenceFeatureProvider(IExecutionContext executionContext)
+        public MetadataReferenceFeatureProvider(DynamicAssemblyCollection dynamicAssemblies)
         {
-            _executionContext = executionContext;
+            _dynamicAssemblies = dynamicAssemblies;
         }
 
         public void PopulateFeature(IEnumerable<ApplicationPart> parts, MetadataReferenceFeature feature)
@@ -36,7 +35,7 @@ namespace Wyam.Razor
             {
                 feature.MetadataReferences.Add(MetadataReference.CreateFromFile(assembly.Location));
             }
-            foreach (byte[] image in _executionContext.DynamicAssemblies)
+            foreach (byte[] image in _dynamicAssemblies ?? Enumerable.Empty<byte[]>())
             {
                 feature.MetadataReferences.Add(MetadataReference.CreateFromImage(image));
             }

--- a/src/extensions/Wyam.Razor/NamespaceCollection.cs
+++ b/src/extensions/Wyam.Razor/NamespaceCollection.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wyam.Razor
+{
+    internal class NamespaceCollection : IEnumerable<string>
+    {
+        private readonly string[] _namespaces;
+
+        public NamespaceCollection(IEnumerable<string> namespaces)
+        {
+            _namespaces = namespaces.ToArray();
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            IEnumerable<string> namespaces = _namespaces;
+            return namespaces.GetEnumerator();
+        }
+
+        public override int GetHashCode()
+        {
+            return _namespaces.Length;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as NamespaceCollection;
+            return other != null && _namespaces.SequenceEqual(other._namespaces);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/extensions/Wyam.Razor/Razor.cs
+++ b/src/extensions/Wyam.Razor/Razor.cs
@@ -71,7 +71,6 @@ namespace Wyam.Razor
     /// <include file='Documentation.xml' path='/Documentation/Razor/*' />
     public class Razor : IModule
     {
-        private readonly ConcurrentDictionary<string, CompilationResult> _compilationCache = new ConcurrentDictionary<string, CompilationResult>();
         private readonly Type _basePageType;
         private DocumentConfig _viewStartPath;
         private DocumentConfig _layoutPath;
@@ -197,200 +196,46 @@ namespace Wyam.Razor
         /// <inheritdoc />
         public IEnumerable<IDocument> Execute(IReadOnlyList<IDocument> inputs, IExecutionContext context)
         {
-            // Register all the MVC and Razor services
-            // In the future, if DI is implemented for all Wyam, the IExecutionContext would be registered as a service
-            // and the IHostingEnviornment would be registered as transient with the execution context provided in ctor
-            IServiceCollection serviceCollection = new ServiceCollection();
-            IMvcCoreBuilder builder = serviceCollection
-                .AddMvcCore()
-                .AddRazorViewEngine();
-            builder.PartManager.FeatureProviders.Add(new MetadataReferenceFeatureProvider(context));
-            serviceCollection.Configure<RazorViewEngineOptions>(options =>
-            {
-                options.ViewLocationExpanders.Add(new ViewLocationExpander());
-            });
-            serviceCollection
-                .AddSingleton<ILoggerFactory, TraceLoggerFactory>()
-                .AddSingleton<DiagnosticSource, SilentDiagnosticSource>()
-                .AddSingleton<IHostingEnvironment, HostingEnvironment>()
-                .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()
-                .AddSingleton<IExecutionContext>(context)
-                .AddSingleton<IBasePageTypeProvider>(new BasePageTypeProvider(_basePageType ?? typeof(WyamRazorPage<>)))
-                .AddScoped<IMvcRazorHost, RazorHost>();
-            IServiceProvider services = serviceCollection.BuildServiceProvider();
-
             // Eliminate input documents that we shouldn't process
             List<IDocument> validInputs = inputs
                 .Where(context, x => _ignorePrefix == null
                     || !x.ContainsKey(Keys.SourceFileName)
                     || !x.FilePath(Keys.SourceFileName).FullPath.StartsWith(_ignorePrefix))
                 .ToList();
+
             if (validInputs.Count < inputs.Count)
             {
                 Trace.Information($"Ignoring {inputs.Count - validInputs.Count} inputs due to source file name prefix");
             }
 
             // Compile and evaluate the pages in parallel
-            IServiceScopeFactory scopeFactory = services.GetRequiredService<IServiceScopeFactory>();
             return validInputs.AsParallel().Select(context, input =>
             {
                 Trace.Verbose("Processing Razor for {0}", input.SourceString());
-                using (IServiceScope scope = scopeFactory.CreateScope())
+
+                Stream contentStream = context.GetContentStream();
+                using (Stream inputStream = input.GetStream())
                 {
-                    // Get services
-                    IRazorViewEngine viewEngine = scope.ServiceProvider.GetRequiredService<IRazorViewEngine>();
-                    IRazorPageActivator pageActivator = scope.ServiceProvider.GetRequiredService<IRazorPageActivator>();
-                    HtmlEncoder htmlEncoder = scope.ServiceProvider.GetRequiredService<HtmlEncoder>();
-                    IRazorPageFactoryProvider pageFactoryProvider = scope.ServiceProvider.GetRequiredService<IRazorPageFactoryProvider>();
-                    IRazorCompilationService razorCompilationService = scope.ServiceProvider.GetRequiredService<IRazorCompilationService>();
-                    IHostingEnvironment hostingEnviornment = scope.ServiceProvider.GetRequiredService<IHostingEnvironment>();
-
-                    // Compile the view
-                    string relativePath = GetRelativePath(input, context);
                     FilePath viewStartLocationPath = _viewStartPath?.Invoke<FilePath>(input, context);
-                    string viewStartLocation = viewStartLocationPath != null ? GetRelativePath(viewStartLocationPath, context) : null;
-                    string layoutLocation = _layoutPath?.Invoke<FilePath>(input, context)?.FullPath;
-                    IView view;
-                    using (Stream stream = input.GetStream())
-                    {
-                        view = GetViewFromStream(
-                            relativePath,
-                            stream,
-                            viewStartLocation,
-                            layoutLocation,
-                            viewEngine,
-                            pageActivator,
-                            htmlEncoder,
-                            pageFactoryProvider,
-                            hostingEnviornment.WebRootFileProvider,
-                            razorCompilationService);
-                    }
 
-                    // Render the view
-                    object model = _model == null ? input : _model.Invoke(input, context);
-                    Stream contentStream = context.GetContentStream();
-                    using (StreamWriter writer = contentStream.GetWriter())
+                    RenderRequest request = new RenderRequest
                     {
-                        Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext =
-                            GetViewContext(scope.ServiceProvider, view, model, input, context, writer);
-                        viewContext.View.RenderAsync(viewContext).GetAwaiter().GetResult();
-                        writer.Flush();
-                    }
-                    return context.GetDocument(input, contentStream);
+                        Input = inputStream,
+                        Output = contentStream,
+                        BaseType = _basePageType,
+                        Context = context,
+                        Document = input,
+                        LayoutLocation = _layoutPath?.Invoke<FilePath>(input, context)?.FullPath,
+                        ViewStartLocation = viewStartLocationPath != null ? GetRelativePath(viewStartLocationPath, context) : null,
+                        RelativePath = GetRelativePath(input, context),
+                        Model = _model == null ? input : _model.Invoke(input, context),
+                    };
+
+                    RazorService.Instance.Render(request);
                 }
+
+                return context.GetDocument(input, contentStream);
             });
-        }
-
-        private Microsoft.AspNetCore.Mvc.Rendering.ViewContext GetViewContext(
-            IServiceProvider services,
-            IView view,
-            object model,
-            IDocument document,
-            IExecutionContext executionContext,
-            TextWriter output)
-        {
-            HttpContext httpContext = new DefaultHttpContext
-            {
-                RequestServices = services
-            };
-            ActionContext actionContext = new ActionContext(
-                httpContext, new RouteData(), new ActionDescriptor());
-            ViewDataDictionary viewData = new ViewDataDictionary(
-                new EmptyModelMetadataProvider(), actionContext.ModelState)
-            {
-                Model = model
-            };
-            ITempDataDictionary tempData = new TempDataDictionary(
-                actionContext.HttpContext, services.GetRequiredService<ITempDataProvider>());
-            ViewContext viewContext = new ViewContext(
-                actionContext,
-                view,
-                viewData,
-                tempData,
-                output,
-                new HtmlHelperOptions(),
-                document,
-                executionContext);
-            return viewContext;
-        }
-
-        /// <summary>
-        /// Gets the view for an input document (which is different than the view for a layout, partial, or
-        /// other indirect view because it's not necessarily on disk or in the file system).
-        /// </summary>
-        private IView GetViewFromStream(
-            string relativePath,
-            Stream stream,
-            string viewStartLocation,
-            string layoutLocation,
-            IRazorViewEngine viewEngine,
-            IRazorPageActivator pageActivator,
-            HtmlEncoder htmlEncoder,
-            IRazorPageFactoryProvider pageFactoryProvider,
-            IFileProvider rootFileProvider,
-            IRazorCompilationService razorCompilationService)
-        {
-            IEnumerable<string> viewStartLocations = viewStartLocation != null
-                ? new [] { viewStartLocation }
-                : ViewHierarchyUtility.GetViewStartLocations(relativePath);
-            List<IRazorPage> viewStartPages = viewStartLocations
-                .Select(pageFactoryProvider.CreateFactory)
-                .Where(x => x.Success)
-                .Select(x => x.RazorPageFactory())
-                .Reverse()
-                .ToList();
-            IRazorPage page = GetPageFromStream(relativePath, viewStartLocation, layoutLocation, stream, rootFileProvider, razorCompilationService);
-            if (layoutLocation != null)
-            {
-                page.Layout = layoutLocation;
-            }
-            return new RazorView(viewEngine, pageActivator, viewStartPages, page, htmlEncoder);
-        }
-
-        /// <summary>
-        /// Gets the Razor page for an input document stream. This is roughly modeled on
-        /// DefaultRazorPageFactory and CompilerCache. Note that we don't actually bother
-        /// with caching the page if it's from a live stream.
-        /// </summary>
-        private IRazorPage GetPageFromStream(
-            string relativePath,
-            string viewStartLocation,
-            string layoutLocation,
-            Stream stream,
-            IFileProvider rootFileProvider,
-            IRazorCompilationService razorCompilationService)
-        {
-            if (relativePath.StartsWith("~/", StringComparison.Ordinal))
-            {
-                // For tilde slash paths, drop the leading ~ to make it work with the underlying IFileProvider.
-                relativePath = relativePath.Substring(1);
-            }
-
-            // Get the file info by combining the stream content with info found at the document's original location (if any)
-            IFileInfo fileInfo = new StreamFileInfo(rootFileProvider.GetFileInfo(relativePath), stream);
-            RelativeFileInfo relativeFileInfo = new RelativeFileInfo(fileInfo, relativePath);
-
-            // Try to get the compilation from the cache, but only if the stream is empty
-            // Cache key is relative path if no explicit view start or layout OR either/both of those if specified
-            CompilationResult compilationResult = stream.Length == 0
-                ? _compilationCache.GetOrAdd(
-                    viewStartLocation == null
-                        ? (layoutLocation ?? relativePath)
-                        : (layoutLocation == null ? viewStartLocation : viewStartLocation + layoutLocation),
-                    _ => GetCompilation(relativeFileInfo, razorCompilationService))
-                : GetCompilation(relativeFileInfo, razorCompilationService);
-
-            // Create and return the page
-            // We're not actually using the ASP.NET cache, but the CompilerCacheResult ctor contains the logic to create the page factory
-            CompilerCacheResult compilerCacheResult = new CompilerCacheResult(relativePath, compilationResult, Array.Empty<IChangeToken>());
-            return compilerCacheResult.PageFactory();
-        }
-
-        private CompilationResult GetCompilation(RelativeFileInfo relativeFileInfo, IRazorCompilationService razorCompilationService)
-        {
-            CompilationResult compilationResult = razorCompilationService.Compile(relativeFileInfo);
-            compilationResult.EnsureSuccessful();
-            return compilationResult;
         }
 
         private string GetRelativePath(IDocument document, IExecutionContext context)

--- a/src/extensions/Wyam.Razor/RazorHost.cs
+++ b/src/extensions/Wyam.Razor/RazorHost.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Razor.Directives;
@@ -10,7 +11,7 @@ namespace Wyam.Razor
 {
     internal class RazorHost : MvcRazorHost
     {
-        public RazorHost(IExecutionContext executionContext, IChunkTreeCache chunkTreeCache, ITagHelperDescriptorResolver resolver, IBasePageTypeProvider basePageTypeProvider)
+        public RazorHost(NamespaceCollection namespaces, IChunkTreeCache chunkTreeCache, ITagHelperDescriptorResolver resolver, IBasePageTypeProvider basePageTypeProvider)
             : base(chunkTreeCache, resolver)
         {
             // Remove the backtick from generic class names
@@ -26,7 +27,7 @@ namespace Wyam.Razor
             EnableInstrumentation = false;
 
             // Add additional default namespaces from the execution context
-            foreach (string ns in executionContext.Namespaces)
+            foreach (string ns in namespaces)
             {
                 NamespaceImports.Add(ns);
             }

--- a/src/extensions/Wyam.Razor/RazorService.cs
+++ b/src/extensions/Wyam.Razor/RazorService.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.AspNetCore.Mvc.Razor.Internal;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Primitives;
+using Wyam.Common.IO;
+using Wyam.Common.Util;
+
+namespace Wyam.Razor
+{
+    /// <summary>
+    /// Razor compiler should be shared so that pages are only compiled once.
+    /// </summary>
+    internal class RazorService
+    {
+        public static RazorService Instance { get; } = new RazorService();
+
+        private readonly ConcurrentDictionary<CompilationParameters, RazorInterpreter> _compilers
+            = new ConcurrentDictionary<CompilationParameters, RazorInterpreter>();
+
+        public void Render(RenderRequest request)
+        {
+            CompilationParameters parameters = new CompilationParameters
+            {
+                BasePageType = request.BaseType,
+                DynamicAssemblies = new DynamicAssemblyCollection(request.Context.DynamicAssemblies),
+                Namespaces = new NamespaceCollection(request.Context.Namespaces),
+                FileSystem = request.Context.FileSystem
+            };
+
+            RazorInterpreter interpreter = _compilers.GetOrAdd(parameters, _ => new RazorInterpreter(parameters));
+            interpreter.RenderPage(request);
+        }
+
+        /// <summary>
+        /// Holds the references to razor objects based on the compilation parameters.
+        /// </summary>
+        private class RazorInterpreter
+        {
+            private readonly IServiceProvider _serviceProvider;
+            private readonly ConcurrentDictionary<object, CompilationResult> _compilationCache = new ConcurrentDictionary<object, CompilationResult>();
+
+            // Razor is apparently not thread safe when reusing the same host for multiple threads.
+            // We should investigate where to put the lock.
+            private readonly object _lock = new object();
+
+            internal RazorInterpreter(CompilationParameters parameters)
+            {
+                ServiceCollection serviceCollection = new ServiceCollection();
+
+                IMvcCoreBuilder builder = serviceCollection
+                    .AddMvcCore()
+                    .AddRazorViewEngine();
+
+                builder.PartManager.FeatureProviders.Add(new MetadataReferenceFeatureProvider(parameters.DynamicAssemblies));
+                serviceCollection.Configure<RazorViewEngineOptions>(options => { options.ViewLocationExpanders.Add(new ViewLocationExpander()); });
+
+                serviceCollection.AddSingleton(parameters.FileSystem);
+                serviceCollection.AddSingleton<ILoggerFactory, TraceLoggerFactory>();
+                serviceCollection.AddSingleton<ILoggerFactory, TraceLoggerFactory>();
+                serviceCollection.AddSingleton<DiagnosticSource, SilentDiagnosticSource>();
+                serviceCollection.AddSingleton<IHostingEnvironment, HostingEnvironment>();
+                serviceCollection.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
+                serviceCollection.AddSingleton(parameters.Namespaces);
+                serviceCollection.AddSingleton(parameters.DynamicAssemblies);
+                serviceCollection.AddSingleton<IBasePageTypeProvider>(new BasePageTypeProvider(parameters.BasePageType ?? typeof(WyamRazorPage<>)));
+                serviceCollection.AddSingleton<IMvcRazorHost, RazorHost>();
+
+                _serviceProvider = serviceCollection.BuildServiceProvider();
+            }
+
+            public void RenderPage(RenderRequest request)
+            {
+                IRazorPage page = GetPageFromStream(request);
+
+                // Razor is apparently not thread safe when reusing the same host for multiple threads.
+                // We should investigate where to put the lock.
+                lock (_lock)
+                {
+                    IView view = GetViewFromStream(request, page);
+
+                    using (StreamWriter writer = request.Output.GetWriter())
+                    {
+                        Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext = GetViewContext(request, view, writer);
+                        viewContext.View.RenderAsync(viewContext).GetAwaiter().GetResult();
+                    }
+                }
+            }
+
+            private Microsoft.AspNetCore.Mvc.Rendering.ViewContext GetViewContext(RenderRequest request, IView view, TextWriter output)
+            {
+                HttpContext httpContext = new DefaultHttpContext
+                {
+                    RequestServices = _serviceProvider
+                };
+
+                ActionContext actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+                ViewDataDictionary viewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), actionContext.ModelState)
+                {
+                    Model = request.Model
+                };
+
+                ITempDataDictionary tempData = new TempDataDictionary(actionContext.HttpContext, _serviceProvider.GetRequiredService<ITempDataProvider>());
+
+                ViewContext viewContext = new ViewContext(
+                    actionContext,
+                    view,
+                    viewData,
+                    tempData,
+                    output,
+                    new HtmlHelperOptions(),
+                    request.Document,
+                    request.Context);
+
+                return viewContext;
+            }
+
+            /// <summary>
+            /// Gets the view for an input document (which is different than the view for a layout, partial, or
+            /// other indirect view because it's not necessarily on disk or in the file system).
+            /// </summary>
+            private IView GetViewFromStream(RenderRequest request, IRazorPage page)
+            {
+                IEnumerable<string> viewStartLocations = request.ViewStartLocation != null
+                    ? new[] { request.ViewStartLocation }
+                    : ViewHierarchyUtility.GetViewStartLocations(request.RelativePath);
+
+                List<IRazorPage> viewStartPages = viewStartLocations
+                    .Select(_serviceProvider.GetRequiredService<IRazorPageFactoryProvider>().CreateFactory)
+                    .Where(x => x.Success)
+                    .Select(x => x.RazorPageFactory())
+                    .Reverse()
+                    .ToList();
+
+                if (request.LayoutLocation != null)
+                {
+                    page.Layout = request.LayoutLocation;
+                }
+
+                IRazorViewEngine viewEngine = _serviceProvider.GetRequiredService<IRazorViewEngine>();
+                IRazorPageActivator pageActivator = _serviceProvider.GetRequiredService<IRazorPageActivator>();
+                HtmlEncoder htmlEncoder = _serviceProvider.GetRequiredService<HtmlEncoder>();
+
+                return new RazorView(viewEngine, pageActivator, viewStartPages, page, htmlEncoder);
+            }
+
+            /// <summary>
+            /// Gets the Razor page for an input document stream. This is roughly modeled on
+            /// DefaultRazorPageFactory and CompilerCache. Note that we don't actually bother
+            /// with caching the page if it's from a live stream.
+            /// </summary>
+            private IRazorPage GetPageFromStream(RenderRequest request)
+            {
+                string relativePath = request.RelativePath;
+
+                if (relativePath.StartsWith("~/", StringComparison.Ordinal))
+                {
+                    // For tilde slash paths, drop the leading ~ to make it work with the underlying IFileProvider.
+                    relativePath = relativePath.Substring(1);
+                }
+
+                // Get the file info by combining the stream content with info found at the document's original location (if any)
+                IHostingEnvironment hostingEnvironment = _serviceProvider.GetRequiredService<IHostingEnvironment>();
+                IFileInfo fileInfo = new StreamFileInfo(hostingEnvironment.WebRootFileProvider.GetFileInfo(relativePath), request.Input);
+                RelativeFileInfo relativeFileInfo = new RelativeFileInfo(fileInfo, relativePath);
+
+                // Cannot use FileInfo.LastWriteTime since it just returns current time of day.
+                DateTime lastWriteTime = File.GetLastWriteTime(relativeFileInfo.FileInfo.PhysicalPath);
+
+                CompilerCacheResult compilerCacheResult = CompilePage(request, lastWriteTime, relativeFileInfo, relativePath);
+
+                IRazorPage result = compilerCacheResult.PageFactory();
+
+                return result;
+            }
+
+            private CompilerCacheResult CompilePage(RenderRequest request, DateTime lastWriteTime, RelativeFileInfo relativeFileInfo, string relativePath)
+            {
+                // Cache key is just a composite object corresponding to all values that should be considered in the key.
+                var cacheKey = new
+                {
+                    request.LayoutLocation,
+                    request.ViewStartLocation,
+                    request.RelativePath,
+                    lastWriteTime
+                };
+
+                IRazorCompilationService razorCompilationService = _serviceProvider.GetRequiredService<IRazorCompilationService>();
+
+                CompilationResult compilationResult = _compilationCache.GetOrAdd(cacheKey, _ => GetCompilation(relativeFileInfo, razorCompilationService));
+
+                // Create and return the page
+                // We're not actually using the ASP.NET cache, but the CompilerCacheResult ctor contains the logic to create the page factory
+                CompilerCacheResult compilerCacheResult = new CompilerCacheResult(relativePath, compilationResult, Array.Empty<IChangeToken>());
+                return compilerCacheResult;
+            }
+
+            private CompilationResult GetCompilation(RelativeFileInfo relativeFileInfo, IRazorCompilationService razorCompilationService)
+            {
+                CompilationResult compilationResult = razorCompilationService.Compile(relativeFileInfo);
+                compilationResult.EnsureSuccessful();
+                return compilationResult;
+            }
+        }
+
+        private struct CompilationParameters
+        {
+            public IReadOnlyFileSystem FileSystem { get; set; }
+            public NamespaceCollection Namespaces { get; set; }
+            public DynamicAssemblyCollection DynamicAssemblies { get; set; }
+            public Type BasePageType { get; set; }
+        }
+    }
+}

--- a/src/extensions/Wyam.Razor/RenderRequest.cs
+++ b/src/extensions/Wyam.Razor/RenderRequest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using Wyam.Common.Documents;
+using Wyam.Common.Execution;
+
+namespace Wyam.Razor
+{
+    /// <summary>
+    /// All the required parameters to render a Razor view.
+    /// </summary>
+    internal class RenderRequest
+    {
+        public Stream Input { get; set; }
+
+        public Stream Output { get; set; }
+
+        public string RelativePath { get; set; }
+
+        public string ViewStartLocation { get; set; }
+
+        public string LayoutLocation { get; set; }
+
+        public Type BaseType { get; set; }
+
+        public object Model { get; set; }
+
+        public IExecutionContext Context { get; set; }
+
+        public IDocument Document { get; set; }
+    }
+}

--- a/src/extensions/Wyam.Razor/Wyam.Razor.csproj
+++ b/src/extensions/Wyam.Razor/Wyam.Razor.csproj
@@ -328,9 +328,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasePageTypeProvider.cs" />
+    <Compile Include="DynamicAssemblyCollection.cs" />
     <Compile Include="EmptyChangeToken.cs" />
     <Compile Include="IBasePageTypeProvider.cs" />
     <Compile Include="MetadataReferenceFeatureProvider.cs" />
+    <Compile Include="NamespaceCollection.cs" />
+    <Compile Include="RazorService.cs" />
+    <Compile Include="RenderRequest.cs" />
     <Compile Include="ViewDataKeys.cs" />
     <Compile Include="SilentDiagnosticSource.cs" />
     <Compile Include="HostingEnvironment.cs" />


### PR DESCRIPTION
Hello, we are using Wyam internally to generate our websites.

Recently I added a blog module and the hot reload time went up to more than 30 seconds for a relatively small web site. I found it reduced a lot my appreciation of the product in comparison to my 5 seconds previewing time I had before.

After some profiling, I found that it was spending most of its time in Razor which was recompiling the same cshtml files over and over.

In this merge request, I removed the states to a maximum so I can reuse the same ASP.net objects on hot reloads. With that, I have a time of around 1 second for a live preview instead of around 40 otherwise.

The only thing that I'm not really comfortable with is that these ASP objects do not seem thread safe so I had to use a mutex. I'm sure there is a better way, I just don't know that much Razor concepts and where the cache lives.