### PR TITLE
Cache Emitted Config

### DIFF
--- a/src/clients/Wyam/Commands/BuildCommand.cs
+++ b/src/clients/Wyam/Commands/BuildCommand.cs
@@ -69,7 +69,8 @@ namespace Wyam.Commands
             syntax.DefineOption("use-global-sources", ref _configOptions.UseGlobalSources, "Toggles the use of the global NuGet sources (default is false).");
             syntax.DefineOption("packages-path", ref _configOptions.PackagesPath, DirectoryPathFromArg, "The packages path to use (only if use-local is true).");
             syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging.");
-            syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute.");
+            syntax.DefineOption("ignore-config-hash", ref _configOptions.IgnoreConfigHash, "Force evaluating the configuration file, even when no changes were detected.");
+            syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute. Consider using the --ignore-config-hash directive when using this option.");
             syntax.DefineOption("noclean", ref _configOptions.NoClean, "Prevents cleaning of the output path on each execution.");
             syntax.DefineOption("nocache", ref _configOptions.NoCache, "Prevents caching information during execution (less memory usage but slower execution).");
 

--- a/src/clients/Wyam/Commands/BuildCommand.cs
+++ b/src/clients/Wyam/Commands/BuildCommand.cs
@@ -69,6 +69,7 @@ namespace Wyam.Commands
             syntax.DefineOption("use-global-sources", ref _configOptions.UseGlobalSources, "Toggles the use of the global NuGet sources (default is false).");
             syntax.DefineOption("packages-path", ref _configOptions.PackagesPath, DirectoryPathFromArg, "The packages path to use (only if use-local is true).");
 
+            syntax.DefineOption("no-output-config-assembly", ref _configOptions.NoOutputConfigAssembly, "Disable caching configuration file compulation.");
             syntax.DefineOption("ignore-config-hash", ref _configOptions.IgnoreConfigHash, "Force evaluating the configuration file, even when no changes were detected.");
             syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging. The directive --ignore-config-hash is required when using this option.");
             syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute. The directive --ignore-config-hash is required when using this option.");

--- a/src/clients/Wyam/Commands/BuildCommand.cs
+++ b/src/clients/Wyam/Commands/BuildCommand.cs
@@ -68,9 +68,20 @@ namespace Wyam.Commands
             syntax.DefineOption("use-local-packages", ref _configOptions.UseLocalPackages, "Toggles the use of a local NuGet packages folder.");
             syntax.DefineOption("use-global-sources", ref _configOptions.UseGlobalSources, "Toggles the use of the global NuGet sources (default is false).");
             syntax.DefineOption("packages-path", ref _configOptions.PackagesPath, DirectoryPathFromArg, "The packages path to use (only if use-local is true).");
-            syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging. Consider using the --ignore-config-hash directive when using this option.");
+
             syntax.DefineOption("ignore-config-hash", ref _configOptions.IgnoreConfigHash, "Force evaluating the configuration file, even when no changes were detected.");
-            syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute. Consider using the --ignore-config-hash directive when using this option.");
+            syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging. The directive --ignore-config-hash is required when using this option.");
+            syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute. The directive --ignore-config-hash is required when using this option.");
+
+            if (_configOptions.OutputScript && !_configOptions.IgnoreConfigHash)
+            {
+                syntax.ReportError("The directive --output-script can only be specified if --ignore-config-hash is also specified.");
+            }
+            if (_verifyConfig && !_configOptions.IgnoreConfigHash)
+            {
+                syntax.ReportError("The directive --verify-config can only be specified if --ignore-config-hash is also specified.");
+            }
+
             syntax.DefineOption("noclean", ref _configOptions.NoClean, "Prevents cleaning of the output path on each execution.");
             syntax.DefineOption("nocache", ref _configOptions.NoCache, "Prevents caching information during execution (less memory usage but slower execution).");
 

--- a/src/clients/Wyam/Commands/BuildCommand.cs
+++ b/src/clients/Wyam/Commands/BuildCommand.cs
@@ -68,7 +68,7 @@ namespace Wyam.Commands
             syntax.DefineOption("use-local-packages", ref _configOptions.UseLocalPackages, "Toggles the use of a local NuGet packages folder.");
             syntax.DefineOption("use-global-sources", ref _configOptions.UseGlobalSources, "Toggles the use of the global NuGet sources (default is false).");
             syntax.DefineOption("packages-path", ref _configOptions.PackagesPath, DirectoryPathFromArg, "The packages path to use (only if use-local is true).");
-            syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging.");
+            syntax.DefineOption("output-script", ref _configOptions.OutputScript, "Outputs the config script after it's been processed for further debugging. Consider using the --ignore-config-hash directive when using this option.");
             syntax.DefineOption("ignore-config-hash", ref _configOptions.IgnoreConfigHash, "Force evaluating the configuration file, even when no changes were detected.");
             syntax.DefineOption("verify-config", ref _verifyConfig, false, "Compile the configuration but do not execute. Consider using the --ignore-config-hash directive when using this option.");
             syntax.DefineOption("noclean", ref _configOptions.NoClean, "Prevents cleaning of the output path on each execution.");

--- a/src/clients/Wyam/Commands/ConfigOptions.cs
+++ b/src/clients/Wyam/Commands/ConfigOptions.cs
@@ -14,6 +14,7 @@ namespace Wyam.Commands
         public DirectoryPath PackagesPath = null;
         public bool OutputScript = false;
         public bool IgnoreConfigHash = false;
+        public bool NoOutputConfigAssembly = false;
         public string Stdin = null;
         public DirectoryPath RootPath = null;
         public IReadOnlyList<DirectoryPath> InputPaths = null;

--- a/src/clients/Wyam/Commands/ConfigOptions.cs
+++ b/src/clients/Wyam/Commands/ConfigOptions.cs
@@ -13,6 +13,7 @@ namespace Wyam.Commands
         public bool UseGlobalSources = false;
         public DirectoryPath PackagesPath = null;
         public bool OutputScript = false;
+        public bool IgnoreConfigHash = false;
         public string Stdin = null;
         public DirectoryPath RootPath = null;
         public IReadOnlyList<DirectoryPath> InputPaths = null;

--- a/src/clients/Wyam/EngineManager.cs
+++ b/src/clients/Wyam/EngineManager.cs
@@ -85,6 +85,9 @@ namespace Wyam
             // Script output
             Configurator.OutputScript = _configOptions.OutputScript;
 
+            // Config caching options
+            Configurator.IgnoreConfigHash = _configOptions.IgnoreConfigHash;
+
             // Application input
             Engine.ApplicationInput = _configOptions.Stdin;
         }
@@ -120,6 +123,8 @@ namespace Wyam
                 {
                     Trace.Information("Loading configuration from {0}", configFile.Path);
                     Configurator.OutputScriptPath = configFile.Path.ChangeExtension(".generated.cs");
+                    Configurator.ConfigDllPath = configFile.Path.ChangeExtension(".dll");
+                    Configurator.ConfigHashPath = configFile.Path.ChangeExtension(".hash");
                     Configurator.Configure(configFile.ReadAllText());
                 }
                 else

--- a/src/clients/Wyam/EngineManager.cs
+++ b/src/clients/Wyam/EngineManager.cs
@@ -123,8 +123,8 @@ namespace Wyam
                 {
                     Trace.Information("Loading configuration from {0}", configFile.Path);
                     Configurator.OutputScriptPath = configFile.Path.ChangeExtension(".generated.cs");
-                    Configurator.ConfigDllPath = configFile.Path.ChangeExtension(".dll");
-                    Configurator.ConfigHashPath = configFile.Path.ChangeExtension(".hash");
+                    Configurator.ConfigDllPath = configFile.Path.ChangeExtension(".wyam.dll");
+                    Configurator.ConfigHashPath = configFile.Path.ChangeExtension(".wyam.hash");
                     Configurator.Configure(configFile.ReadAllText());
                 }
                 else

--- a/src/clients/Wyam/EngineManager.cs
+++ b/src/clients/Wyam/EngineManager.cs
@@ -86,6 +86,7 @@ namespace Wyam
             Configurator.OutputScript = _configOptions.OutputScript;
 
             // Config caching options
+            Configurator.NoOutputConfigAssembly = _configOptions.NoOutputConfigAssembly;
             Configurator.IgnoreConfigHash = _configOptions.IgnoreConfigHash;
 
             // Application input

--- a/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
+++ b/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+using Wyam.Common.Execution;
+using Wyam.Common.IO;
+
+namespace Wyam.Configuration.ConfigScript
+{
+    public class CacheManager
+    {
+        private readonly IEngine _engine;
+        private readonly IScriptManager _scriptManager;
+
+        public FilePath ConfigDllPath { get; }
+
+        public FilePath ConfigHashPath { get; }
+
+        public FilePath OutputScriptPath { get; }
+
+        internal CacheManager(IEngine engine, IScriptManager scriptManager, FilePath configDllPath, FilePath configHashPath, FilePath outputScriptPath)
+        {
+            _engine = engine;
+            _scriptManager = scriptManager;
+            ConfigDllPath = configDllPath;
+            ConfigHashPath = configHashPath;
+            OutputScriptPath = outputScriptPath;
+        }
+
+        public void EvaluateCode(string code, IReadOnlyCollection<Type> classes, bool outputScript, bool ignoreConfigHash)
+        {
+            string cachedHash = GetCachedConfigHash();
+            string currentHash = HashString(code);
+
+            bool discardCache = cachedHash != currentHash || ignoreConfigHash;
+
+            if (discardCache)
+            {
+                _scriptManager.Create(code, classes, _engine.Namespaces);
+                WriteScript(_scriptManager.Code, outputScript);
+                _scriptManager.Compile(AppDomain.CurrentDomain.GetAssemblies());
+                SaveCompiledScript(currentHash);
+            }
+            else
+            {
+                byte[] cachedConfig = GetCachedConfig();
+                _scriptManager.LoadCompiledConfig(cachedConfig);
+            }
+
+            _engine.DynamicAssemblies.Add(_scriptManager.RawAssembly);
+            _scriptManager.Evaluate(_engine);
+        }
+
+        private string GetCachedConfigHash()
+        {
+            if (ConfigHashPath == null)
+            {
+                return null;
+            }
+            IFile configHashFile = _engine.FileSystem.GetRootFile(ConfigHashPath);
+            string hash = null;
+            if (configHashFile?.Exists == true)
+            {
+                hash = configHashFile.ReadAllText();
+            }
+            return hash;
+        }
+
+        private byte[] GetCachedConfig()
+        {
+            IFile configDllFile = _engine.FileSystem.GetRootFile(ConfigDllPath);
+            using (Stream stream = configDllFile.OpenRead())
+            using (MemoryStream memory = new MemoryStream())
+            {
+                stream.CopyTo(memory);
+                return memory.ToArray();
+            }
+        }
+
+        private void SaveCompiledScript(string scriptHash)
+        {
+            if (ConfigHashPath == null || ConfigDllPath == null)
+            {
+                return;
+            }
+
+            IFile configHashFile = _engine.FileSystem.GetRootFile(ConfigHashPath);
+            configHashFile.WriteAllText(scriptHash);
+
+            IFile configDllFile = _engine.FileSystem.GetRootFile(ConfigDllPath);
+            using (MemoryStream memory = new MemoryStream(_scriptManager.RawAssembly))
+            using (Stream stream = configDllFile.OpenWrite())
+            {
+                memory.CopyTo(stream);
+            }
+        }
+
+        private void WriteScript(string code, bool outputScript)
+        {
+            // Output only if requested
+            if (outputScript)
+            {
+                FilePath outputPath = _engine.FileSystem.RootPath.CombineFile(OutputScriptPath ?? new FilePath($"{ScriptManager.AssemblyName}.cs"));
+                _engine.FileSystem.GetFile(outputPath)?.WriteAllText(code);
+            }
+        }
+
+        private static string HashString(string input)
+        {
+            // https://stackoverflow.com/a/24031467/2001966 with simplifications.
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] inputBytes = Encoding.UTF8.GetBytes(input);
+                byte[] hashBytes = md5.ComputeHash(inputBytes);
+
+                StringBuilder sb = new StringBuilder();
+                foreach (byte t in hashBytes)
+                {
+                    sb.Append(t.ToString("X2"));
+                }
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
+++ b/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
@@ -29,7 +29,7 @@ namespace Wyam.Configuration.ConfigScript
             OutputScriptPath = outputScriptPath;
         }
 
-        public void EvaluateCode(string code, IReadOnlyCollection<Type> classes, bool outputScript, bool ignoreConfigHash)
+        public void EvaluateCode(string code, IReadOnlyCollection<Type> classes, bool outputScript, bool ignoreConfigHash, bool noOutputConfigAssembly)
         {
             string cachedHash = GetCachedConfigHash();
             string currentHash = HashString(code);
@@ -41,7 +41,7 @@ namespace Wyam.Configuration.ConfigScript
                 _scriptManager.Create(code, classes, _engine.Namespaces);
                 WriteScript(_scriptManager.Code, outputScript);
                 _scriptManager.Compile(AppDomain.CurrentDomain.GetAssemblies());
-                SaveCompiledScript(currentHash);
+                SaveCompiledScript(currentHash, noOutputConfigAssembly);
             }
             else
             {
@@ -81,9 +81,9 @@ namespace Wyam.Configuration.ConfigScript
             }
         }
 
-        private void SaveCompiledScript(string scriptHash)
+        private void SaveCompiledScript(string scriptHash, bool noOutputConfigAssembly)
         {
-            if (ConfigHashPath == null || ConfigDllPath == null)
+            if (noOutputConfigAssembly || ConfigHashPath == null || ConfigDllPath == null)
             {
                 return;
             }

--- a/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
+++ b/src/core/Wyam.Configuration/ConfigScript/CacheManager.cs
@@ -9,7 +9,7 @@ using Wyam.Common.IO;
 
 namespace Wyam.Configuration.ConfigScript
 {
-    public class CacheManager
+    internal class CacheManager
     {
         private readonly IEngine _engine;
         private readonly IScriptManager _scriptManager;
@@ -72,10 +72,12 @@ namespace Wyam.Configuration.ConfigScript
         {
             IFile configDllFile = _engine.FileSystem.GetRootFile(ConfigDllPath);
             using (Stream stream = configDllFile.OpenRead())
-            using (MemoryStream memory = new MemoryStream())
             {
-                stream.CopyTo(memory);
-                return memory.ToArray();
+                using (MemoryStream memory = new MemoryStream())
+                {
+                    stream.CopyTo(memory);
+                    return memory.ToArray();
+                }
             }
         }
 
@@ -91,9 +93,11 @@ namespace Wyam.Configuration.ConfigScript
 
             IFile configDllFile = _engine.FileSystem.GetRootFile(ConfigDllPath);
             using (MemoryStream memory = new MemoryStream(_scriptManager.RawAssembly))
-            using (Stream stream = configDllFile.OpenWrite())
             {
-                memory.CopyTo(stream);
+                using (Stream stream = configDllFile.OpenWrite())
+                {
+                    memory.CopyTo(stream);
+                }
             }
         }
 

--- a/src/core/Wyam.Configuration/ConfigScript/IScriptManager.cs
+++ b/src/core/Wyam.Configuration/ConfigScript/IScriptManager.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Wyam.Common.Execution;
+
+namespace Wyam.Configuration.ConfigScript
+{
+    internal interface IScriptManager
+    {
+        string Code { get; }
+        Assembly Assembly { get; }
+        string AssemblyFullName { get; }
+        byte[] RawAssembly { get; }
+        void Compile(IReadOnlyCollection<Assembly> referenceAssemblies);
+        void LoadCompiledConfig(byte[] rawAssembly);
+        void Evaluate(IEngine engine);
+        void Create(string code, IReadOnlyCollection<Type> moduleTypes, IEnumerable<string> namespaces);
+    }
+}

--- a/src/core/Wyam.Configuration/ConfigScript/ScriptManager.cs
+++ b/src/core/Wyam.Configuration/ConfigScript/ScriptManager.cs
@@ -11,22 +11,9 @@ using Microsoft.CodeAnalysis.Text;
 
 using Wyam.Common.Execution;
 using Wyam.Common.Tracing;
-using Wyam.Core.Execution;
 
 namespace Wyam.Configuration.ConfigScript
 {
-    internal interface IScriptManager
-    {
-        string Code { get; }
-        Assembly Assembly { get; }
-        string AssemblyFullName { get; }
-        byte[] RawAssembly { get; }
-        void Compile(IReadOnlyCollection<Assembly> referenceAssemblies);
-        void LoadCompiledConfig(byte[] rawAssembly);
-        void Evaluate(IEngine engine);
-        void Create(string code, IReadOnlyCollection<Type> moduleTypes, IEnumerable<string> namespaces);
-    }
-
     internal class ScriptManager : IScriptManager
     {
         public const string AssemblyName = "WyamConfig";

--- a/src/core/Wyam.Configuration/Configurator.cs
+++ b/src/core/Wyam.Configuration/Configurator.cs
@@ -44,6 +44,8 @@ namespace Wyam.Configuration
 
         public bool IgnoreConfigHash { get; set; }
 
+        public bool NoOutputConfigAssembly { get; set; }
+
         public FilePath ConfigDllPath { get; set; }
 
         public FilePath ConfigHashPath { get; set; }
@@ -337,7 +339,7 @@ namespace Wyam.Configuration
             using (Trace.WithIndent().Information("Evaluating configuration script"))
             {
                 CacheManager cacheManager = new CacheManager(_engine, _scriptManager, ConfigDllPath, ConfigHashPath, OutputScriptPath);
-                cacheManager.EvaluateCode(code, ClassCatalog.GetClasses<IModule>().ToList(), OutputScript, IgnoreConfigHash);
+                cacheManager.EvaluateCode(code, ClassCatalog.GetClasses<IModule>().ToList(), OutputScript, IgnoreConfigHash, NoOutputConfigAssembly);
 
                 stopwatch.Stop();
                 Trace.Information($"Evaluated configuration script in {stopwatch.ElapsedMilliseconds} ms");

--- a/src/core/Wyam.Configuration/Configurator.cs
+++ b/src/core/Wyam.Configuration/Configurator.cs
@@ -1,16 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
 using Wyam.Common.Configuration;
 using Wyam.Common.IO;
 using Wyam.Common.Modules;
-using Wyam.Common.Tracing;
 using Wyam.Configuration.Assemblies;
 using Wyam.Configuration.ConfigScript;
 using Wyam.Configuration.NuGet;
 using Wyam.Configuration.Preprocessing;
 using Wyam.Core.Execution;
+
+using Trace = Wyam.Common.Tracing.Trace;
 
 namespace Wyam.Configuration
 {
@@ -36,6 +41,12 @@ namespace Wyam.Configuration
         public bool OutputScript { get; set; }
 
         public FilePath OutputScriptPath { get; set; }
+
+        public bool IgnoreConfigHash { get; set; }
+
+        public FilePath ConfigDllPath { get; set; }
+
+        public FilePath ConfigHashPath { get; set; }
 
         public IReadOnlyDictionary<string, object> Settings { get; set; }
 
@@ -220,7 +231,7 @@ namespace Wyam.Configuration
 
         private void InstallPackages()
         {
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Stopwatch stopwatch = Stopwatch.StartNew();
             using (Trace.WithIndent().Information("Installing NuGet packages"))
             {
                 PackageInstaller.InstallPackages();
@@ -231,7 +242,7 @@ namespace Wyam.Configuration
 
         private void LoadAssemblies()
         {
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Stopwatch stopwatch = Stopwatch.StartNew();
             using (Trace.WithIndent().Information("Recursively loading assemblies"))
             {
                 AssemblyLoader.Load();
@@ -242,7 +253,7 @@ namespace Wyam.Configuration
 
         private void CatalogClasses()
         {
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Stopwatch stopwatch = Stopwatch.StartNew();
             using (Trace.WithIndent().Information("Cataloging classes"))
             {
                 ClassCatalog.CatalogTypes(AssemblyLoader.DirectAssemblies);
@@ -322,26 +333,14 @@ namespace Wyam.Configuration
                 return;
             }
 
-            System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            Stopwatch stopwatch = Stopwatch.StartNew();
             using (Trace.WithIndent().Information("Evaluating configuration script"))
             {
-                _scriptManager.Create(code, ClassCatalog.GetClasses<IModule>().ToList(), _engine.Namespaces);
-                WriteScript(_scriptManager.Code);
-                _scriptManager.Compile(AppDomain.CurrentDomain.GetAssemblies());
-                _engine.DynamicAssemblies.Add(_scriptManager.RawAssembly);
-                _scriptManager.Evaluate(_engine);
+                CacheManager cacheManager = new CacheManager(_engine, _scriptManager, ConfigDllPath, ConfigHashPath, OutputScriptPath);
+                cacheManager.EvaluateCode(code, ClassCatalog.GetClasses<IModule>().ToList(), OutputScript, IgnoreConfigHash);
+
                 stopwatch.Stop();
                 Trace.Information($"Evaluated configuration script in {stopwatch.ElapsedMilliseconds} ms");
-            }
-        }
-
-        private void WriteScript(string code)
-        {
-            // Output only if requested
-            if (OutputScript)
-            {
-                FilePath outputPath = _engine.FileSystem.RootPath.CombineFile(OutputScriptPath ?? new FilePath($"{ScriptManager.AssemblyName}.cs"));
-                _engine.FileSystem.GetFile(outputPath)?.WriteAllText(code);
             }
         }
     }

--- a/src/core/Wyam.Configuration/Properties/AssemblyInfo.cs
+++ b/src/core/Wyam.Configuration/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("43ccbef4-c940-457e-b6d7-4d2675532926")]
 [assembly: InternalsVisibleTo("Wyam.Configuration.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/core/Wyam.Configuration/Wyam.Configuration.csproj
+++ b/src/core/Wyam.Configuration/Wyam.Configuration.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Assemblies\AssemblyCollection.cs" />
     <Compile Include="Assemblies\AssemblyResolver.cs" />
     <Compile Include="Assemblies\AssemblyLoader.cs" />
+    <Compile Include="ConfigScript\CacheManager.cs" />
     <Compile Include="ConfigScript\LiftingWalker.cs" />
     <Compile Include="ConfigScript\ScriptCompilationException.cs" />
     <Compile Include="Directives\AssemblyDirective.cs" />

--- a/src/core/Wyam.Configuration/Wyam.Configuration.csproj
+++ b/src/core/Wyam.Configuration/Wyam.Configuration.csproj
@@ -233,6 +233,7 @@
     <Compile Include="Assemblies\AssemblyResolver.cs" />
     <Compile Include="Assemblies\AssemblyLoader.cs" />
     <Compile Include="ConfigScript\CacheManager.cs" />
+    <Compile Include="ConfigScript\IScriptManager.cs" />
     <Compile Include="ConfigScript\LiftingWalker.cs" />
     <Compile Include="ConfigScript\ScriptCompilationException.cs" />
     <Compile Include="Directives\AssemblyDirective.cs" />

--- a/tests/core/Wyam.Configuration.Tests/ConfigScript/CacheManagerFixture.cs
+++ b/tests/core/Wyam.Configuration.Tests/ConfigScript/CacheManagerFixture.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+using Ploeh.AutoFixture;
+
+using Wyam.Common.Execution;
+using Wyam.Common.IO;
+using Wyam.Configuration.ConfigScript;
+using Wyam.Testing;
+using Wyam.Testing.IO;
+
+namespace Wyam.Configuration.Tests.ConfigScript
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.Self | ParallelScope.Children)]
+    public class CacheManagerFixture : BaseFixture
+    {
+        public class CacheManagerTests : CacheManagerFixture
+        {
+            private static readonly Fixture Autofixture = new Fixture();
+
+            [Test]
+            public void WhenNoCacheExistsThenEvaluate()
+            {
+                // Given
+                string fakeCode = Autofixture.Create<string>();
+                IReadOnlyCollection<Type> fakeClasses = Autofixture.CreateMany<Type>().ToList();
+
+                CacheManager cacheManager = CreateCacheManager(out IEngine mockEngine, out IScriptManager mockScriptManager);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Exists.Returns(false);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigDllPath).OpenWrite().Returns(new MemoryStream());
+
+                // When
+                cacheManager.EvaluateCode(fakeCode, fakeClasses, false, false);
+
+                // Then
+                mockScriptManager.Received().Create(fakeCode, fakeClasses, Arg.Any<IEnumerable<string>>());
+            }
+
+            [Test]
+            public void WhenNoCacheExistsThenSaveNewHashToCache()
+            {
+                // Given
+                const string fakeCode = "8AC5716A-3272-4CBA-A787-B93B198E77B4";
+                const string fakeCodeHash = "60FB4943418545ECE2A9CAB2B07C5C17";
+
+                CacheManager cacheManager = CreateCacheManager(out IEngine mockEngine, out IScriptManager _);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Exists.Returns(false);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigDllPath).OpenWrite().Returns(new MemoryStream());
+
+                // When
+                cacheManager.EvaluateCode(fakeCode, Autofixture.CreateMany<Type>().ToList(), false, false);
+
+                // Then
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Received().WriteAllText(fakeCodeHash);
+            }
+
+            [Test]
+            public void WhenNoCacheExistsThenSaveCompiledDllToCache()
+            {
+                // Given
+                CacheManager cacheManager = CreateCacheManager(out IEngine mockEngine, out IScriptManager scriptManager);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Exists.Returns(false);
+
+                scriptManager.RawAssembly.Returns(Autofixture.CreateMany<byte>().ToArray());
+
+                MockStream cacheStream = new MockStream();
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigDllPath).OpenWrite().Returns(cacheStream);
+
+                // When
+                cacheManager.EvaluateCode(Autofixture.Create<string>(), Autofixture.CreateMany<Type>().ToList(), false, false);
+
+                // Then
+                Assert.AreEqual(scriptManager.RawAssembly, cacheStream.MemoryStream.ToArray());
+            }
+
+            [Test]
+            public void WhenCacheExistsAndHashesAreSameThenUseCachedConfig()
+            {
+                // Given
+                const string fakeCode = "8AC5716A-3272-4CBA-A787-B93B198E77B4";
+                const string fakeCodeHash = "60FB4943418545ECE2A9CAB2B07C5C17";
+
+                CacheManager cacheManager = CreateCacheManager(out IEngine mockEngine, out IScriptManager scriptManager);
+
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Exists.Returns(true);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).ReadAllText().Returns(fakeCodeHash);
+
+                byte[] fakeAssembly = Autofixture.CreateMany<byte>().ToArray();
+                MemoryStream cacheStream = new MemoryStream(fakeAssembly);
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigDllPath).OpenRead().Returns(cacheStream);
+
+                // When
+                cacheManager.EvaluateCode(fakeCode, Autofixture.CreateMany<Type>().ToList(), false, false);
+
+                // Then
+                scriptManager.Received().LoadCompiledConfig(Arg.Is<byte[]>(x => fakeAssembly.SequenceEqual(x)));
+            }
+
+            private CacheManager CreateCacheManager(out IEngine mockEngine, out IScriptManager mockScriptManager)
+            {
+                mockEngine = Substitute.For<IEngine>();
+                mockEngine.FileSystem.Returns(Substitute.For<IFileSystem>());
+                mockScriptManager = Substitute.For<IScriptManager>();
+
+                CacheManager cacheManager = new CacheManager(mockEngine, mockScriptManager, FakeFilePath(), FakeFilePath(), FakeFilePath());
+
+                IFile mockHashFile = Substitute.For<IFile>();
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigHashPath).Returns(mockHashFile);
+
+                IFile mockCacheFile = Substitute.For<IFile>();
+                mockEngine.FileSystem.GetRootFile(cacheManager.ConfigDllPath).Returns(mockCacheFile);
+
+                IFile mockOutputScript = Substitute.For<IFile>();
+                mockEngine.FileSystem.GetRootFile(cacheManager.OutputScriptPath).Returns(mockOutputScript);
+
+                return cacheManager;
+            }
+
+            private FilePath FakeFilePath()
+            {
+                string fakePathStr = Autofixture.Create<string>();
+                FilePath path = new FilePath(fakePathStr);
+                return path;
+            }
+
+            private class MockStream : Stream
+            {
+                public MemoryStream MemoryStream { get; } = new MemoryStream();
+
+                public override void Flush()
+                {
+                    MemoryStream.Flush();
+                }
+
+                public override long Seek(long offset, SeekOrigin origin)
+                {
+                    return MemoryStream.Seek(offset, origin);
+                }
+
+                public override void SetLength(long value)
+                {
+                    MemoryStream.SetLength(value);
+                }
+
+                public override int Read(byte[] buffer, int offset, int count)
+                {
+                    return MemoryStream.Read(buffer, offset, count);
+                }
+
+                public override void Write(byte[] buffer, int offset, int count)
+                {
+                    MemoryStream.Write(buffer, offset, count);
+                }
+
+                public override bool CanRead => MemoryStream.CanRead;
+                public override bool CanSeek => MemoryStream.CanSeek;
+                public override bool CanWrite => MemoryStream.CanWrite;
+                public override long Length => MemoryStream.Length;
+                public override long Position { get => MemoryStream.Position; set => MemoryStream.Position = value; }
+            }
+        }
+    }
+}

--- a/tests/core/Wyam.Configuration.Tests/ConfigScript/ScriptManagerFixture.cs
+++ b/tests/core/Wyam.Configuration.Tests/ConfigScript/ScriptManagerFixture.cs
@@ -53,7 +53,6 @@ namespace Wyam.Configuration.Tests.ConfigScript
             public void CorrectlyParsesScriptCode(string input, string output)
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string usingStatements = "using Foo.Bar;";
@@ -63,7 +62,7 @@ $@"#line 1
                 string expected = GetExpected(usingStatements, string.Empty, scriptCode, string.Empty, string.Empty, string.Empty);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());
@@ -73,7 +72,6 @@ $@"#line 1
             public void LiftsClassDeclarations()
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string input =
@@ -125,7 +123,7 @@ public class Baz
                 string expected = GetExpected(usingStatements, string.Empty, scriptCode, string.Empty, typeDeclarations, string.Empty);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());
@@ -135,7 +133,6 @@ public class Baz
             public void LiftsUsingDirectives()
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string input =
@@ -181,7 +178,7 @@ public string Self(string x)
                 string expected = GetExpected(usingStatements, usingDirectives, scriptCode, methodDeclarations, typeDeclarations, string.Empty);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());
@@ -191,7 +188,6 @@ public string Self(string x)
             public void LiftsMethodDeclarations()
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string input =
@@ -229,7 +225,7 @@ public string Self(string x)
                 string expected = GetExpected(usingStatements, string.Empty, scriptCode, methodDeclarations, typeDeclarations, string.Empty);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());
@@ -239,7 +235,6 @@ public string Self(string x)
             public void LiftsExtensionMethodDeclarations()
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string input =
@@ -277,7 +272,7 @@ public static string Self(this string x)
                 string expected = GetExpected(usingStatements, string.Empty, scriptCode, string.Empty, typeDeclarations, extensionMethodDeclarations);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());
@@ -287,7 +282,6 @@ public static string Self(this string x)
             public void LiftsCommentsWithDeclarations()
             {
                 // Given
-                ScriptManager scriptManager = new ScriptManager();
                 HashSet<Type> moduleTypes = new HashSet<Type> { typeof(Content) };
                 string[] namespaces = { "Foo.Bar" };
                 string input =
@@ -335,7 +329,7 @@ public string Self(string x)
                 string expected = GetExpected(usingStatements, string.Empty, scriptCode, methodDeclarations, typeDeclarations, string.Empty);
 
                 // When
-                string actual = scriptManager.Parse(input, moduleTypes, namespaces);
+                string actual = ScriptManager.Parse(input, moduleTypes, namespaces);
 
                 // Then
                 Assert.AreEqual(expected.NormalizeLineEndings(), actual.NormalizeLineEndings());

--- a/tests/core/Wyam.Configuration.Tests/Wyam.Configuration.Tests.csproj
+++ b/tests/core/Wyam.Configuration.Tests/Wyam.Configuration.Tests.csproj
@@ -56,6 +56,9 @@
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AutoFixture.3.50.6\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
@@ -171,6 +174,7 @@
     <Compile Include="..\..\..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="ConfigScript\CacheManagerFixture.cs" />
     <Compile Include="ConfigScript\ScriptManagerFixture.cs" />
     <Compile Include="ConfigScript\DirectiveParserFixture.cs" />
     <Compile Include="ConfiguratorFixture.cs" />

--- a/tests/core/Wyam.Configuration.Tests/packages.config
+++ b/tests/core/Wyam.Configuration.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoFixture" version="3.50.6" targetFramework="net462" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net462" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.0.0" targetFramework="net462" />


### PR DESCRIPTION
Implementation of #97. This pull adds the following.

* Added the ability to cache the `config.wyam` config generation.
* The cache will be broken when the MD5 hash of the code generated by the `DirectiveParser` differs in-between runs.
* Added the command directive `ignore-config-hash`, which forces evaluation even when the two hashes match (current and cached hash).