### PR TITLE
Disable Data Protection Services

### DIFF
--- a/src/extensions/Wyam.Razor/RazorCompiler.cs
+++ b/src/extensions/Wyam.Razor/RazorCompiler.cs
@@ -6,6 +6,11 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
+using System.Threading;
+using System.Xml.Linq;
+
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +23,7 @@ using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
@@ -48,6 +54,9 @@ namespace Wyam.Razor
             {
                 options.ViewLocationExpanders.Add(new ViewLocationExpander());
             });
+
+            // Disables the configuration of the DataProtection services, which we don't need for just razor generation.
+            serviceCollection.AddTransient<IXmlRepository, DummyXmlRepository>();
 
             serviceCollection
                 .AddSingleton(parameters.FileSystem)
@@ -198,6 +207,18 @@ namespace Wyam.Razor
             CompilationResult compilationResult = razorCompilationService.Compile(relativeFileInfo);
             compilationResult.EnsureSuccessful();
             return compilationResult;
+        }
+    }
+
+    internal class DummyXmlRepository : IXmlRepository
+    {
+        public IReadOnlyCollection<XElement> GetAllElements()
+        {
+            return new List<XElement>();
+        }
+
+        public void StoreElement(XElement element, string friendlyName)
+        {
         }
     }
 }


### PR DESCRIPTION
I was trying to find a way to optimize razor compilation, it looked like there was a pause right before these messages are created, slowing down the compilation process during every step:

> Microsoft.Extensions.DependencyInjection.DataProtectionServices: User profile is available. Using 'C:\Users\User\AppData\Local\ASP.NET\DataProtection-Keys' as key repository and Windows DPAPI to encrypt keys at rest.

It turns out it probably doesn't, although removing it might slightly reduce compilation times (as the configuration heuristics run every time a module is declared). Wyam should hopefully never need to use DataProtection services and the messages are kind of useless to a user.

This pull disables the automatic DataProtection configuration heuristics from AspNetCore - which removes the above message.