### PR TITLE
modify glob pattern to include subdirectories

### DIFF
--- a/src/recipes/Wyam.Web/Pipelines/BlogPosts.cs
+++ b/src/recipes/Wyam.Web/Pipelines/BlogPosts.cs
@@ -69,7 +69,7 @@ namespace Wyam.Web.Pipelines
                 MarkdownPosts,
                 new ModuleCollection
                 {
-                    new ReadFiles(ctx => $"{settings.PostsPath.Invoke<string>(ctx)}/{{!_,}}*.md"),
+                    new ReadFiles(ctx => $"{settings.PostsPath.Invoke<string>(ctx)}/**/{{!_,}}*.md"),
                     new Meta(WebKeys.EditFilePath, (doc, ctx) => doc.FilePath(Keys.RelativeFilePath)),
                     new If(settings.ProcessIncludes, new Include()),
                     new FrontMatter(new Yaml.Yaml()),


### PR DESCRIPTION
Markdown files within sub-folders of the input blog folder did not have corresponding HTML files in output. 

Setting DocsKeys.BlogPath to glob pattern matching files within subfloders causes BlogIndex pipeline to fail on Razor module. It is because the _BlogIndex.cshtml is expecting a path to a folder not a glob. 

Modifying the glob pattern passed to the  ReadFiles module within BlogPosts.cs will allow subfolders to be searched for .md files without negatively impacting the BlogIndex pipeline.