### PR TITLE
AnalyzeCSharp Syntax: More than one C# attribute

### DIFF
--- a/src/extensions/Wyam.CodeAnalysis/Analysis/SyntaxHelper.cs
+++ b/src/extensions/Wyam.CodeAnalysis/Analysis/SyntaxHelper.cs
@@ -82,8 +82,10 @@ namespace Wyam.CodeAnalysis.Analysis
 
             // Attributes
             foreach (SyntaxNode attributeListNode in symbol.GetAttributes()
-                .Select(x => x.ApplicationSyntaxReference?.GetSyntax()?.Parent?.NormalizeWhitespace())
-                .Where(x => x != null))
+                .Select(x => x.ApplicationSyntaxReference?.GetSyntax()?.Parent)
+                .Where(x => x != null)
+                .Distinct()
+                .Select(parent => parent.NormalizeWhitespace()))
             {
                 builder.AppendLine(attributeListNode.ReplaceTrivia(attributeListNode.DescendantTrivia(), (x, y) => new SyntaxTrivia()).NormalizeWhitespace().ToString());
             }

--- a/tests/extensions/Wyam.CodeAnalysis.Tests/AnalyzeCSharpSyntaxFixture.cs
+++ b/tests/extensions/Wyam.CodeAnalysis.Tests/AnalyzeCSharpSyntaxFixture.cs
@@ -127,7 +127,7 @@ namespace Wyam.CodeAnalysis.Tests
                     namespace Foo
                     {
                         [  Foo]
-                        [Bar  ]
+                        [Bar ,Foo ]
                         class Green
                         {
                         }
@@ -143,7 +143,7 @@ namespace Wyam.CodeAnalysis.Tests
                 // Then
                 Assert.AreEqual(
                     @"[Foo]
-[Bar]
+[Bar, Foo]
 internal class Green",
                     GetResult(results, "Green")["Syntax"]);
             }


### PR DESCRIPTION
Fixed the behaviour that two attributes in the same line, e.g. `[Foo, Bar]`, result in duplicate syntax.