### PR TITLE
Updated Cake.Wyam project to use .NET 4.6 and updated the Cake NuGet …

### DIFF
--- a/src/clients/Cake.Wyam/Cake.Wyam.csproj
+++ b/src/clients/Cake.Wyam/Cake.Wyam.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Wyam</RootNamespace>
     <AssemblyName>Cake.Wyam</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
@@ -37,11 +37,11 @@
     <CodeAnalysisRuleSet>..\..\..\wyam.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Common, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Cake.Common.0.17.0\lib\net45\Cake.Common.dll</HintPath>
+    <Reference Include="Cake.Common, Version=0.22.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Cake.Common.0.22.2\lib\net46\Cake.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.22.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -63,7 +63,9 @@
     <Compile Include="WyamSettings.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />

--- a/src/clients/Cake.Wyam/packages.config
+++ b/src/clients/Cake.Wyam/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Common" version="0.17.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Cake.Common" version="0.22.2" targetFramework="net46" developmentDependency="true" />
+  <package id="Cake.Core" version="0.22.2" targetFramework="net46" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
…packages to 0.22.2.

@daveaglick Looks like we can't use the Wyam Cake plugin with newer version of Cake. So build scripts that always pull down the latest version won't work unless the Wyam Cake plugin updates to A) .NET 4.6 and b) Updates the NuGet references to 0.22.2 of Cake.
