### PR TITLE
Fixes Output Corruption When Using No Clean

### DIFF
--- a/Wyam.v3.ncrunchsolution
+++ b/Wyam.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/core/Wyam.Configuration/Wyam.Configuration.v3.ncrunchproject
+++ b/src/core/Wyam.Configuration/Wyam.Configuration.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <AdditionalFilesToIncludeForProject>
+      <Value>..\..\..\themes\**.*</Value>
+    </AdditionalFilesToIncludeForProject>
+  </Settings>
+</ProjectConfiguration>

--- a/src/core/Wyam.Core/Modules/IO/WriteFiles.cs
+++ b/src/core/Wyam.Core/Modules/IO/WriteFiles.cs
@@ -323,6 +323,10 @@ namespace Wyam.Core.Modules.IO
                         using (Stream outputStream = _append ? output.OpenAppend() : output.OpenWrite())
                         {
                             inputStream.CopyTo(outputStream);
+                            if (!_append)
+                            {
+                                outputStream.SetLength(inputStream.Length);
+                            }
                         }
                     }
                 }

--- a/src/core/Wyam.Testing/IO/StringBuilderStream.cs
+++ b/src/core/Wyam.Testing/IO/StringBuilderStream.cs
@@ -20,6 +20,13 @@ namespace Wyam.Testing.IO
         public StringBuilderStream(StringBuilder resultBuilder)
         {
             _buffer = new MemoryStream();
+
+            // Copy the old result into the current buffer.
+            StreamWriter writer = new StreamWriter(_buffer);
+            writer.Write(resultBuilder.ToString());
+            writer.Flush();
+            _buffer.Position = 0;
+
             _bufferReader = new StreamReader(_buffer, true);
             _resultBuilder = resultBuilder;
         }
@@ -30,13 +37,18 @@ namespace Wyam.Testing.IO
 
         public override bool CanWrite => true;
 
-        public override long Length => 0;
+        public override long Length => _buffer.Length;
 
-        public override long Position { get; set; }
+        public override long Position
+        {
+            get => _buffer.Position;
+            set => _buffer.Position = value;
+        }
 
         public override void Flush()
         {
             _buffer.Position = 0;
+            _resultBuilder.Clear();
             _resultBuilder.Append(_bufferReader.ReadToEnd());
             _buffer.SetLength(0);
         }

--- a/src/core/Wyam.Testing/IO/StringBuilderStream.cs
+++ b/src/core/Wyam.Testing/IO/StringBuilderStream.cs
@@ -48,7 +48,7 @@ namespace Wyam.Testing.IO
 
         public override void SetLength(long value)
         {
-            throw new NotSupportedException();
+            _buffer.SetLength(value);
         }
 
         public override int Read(byte[] buffer, int offset, int count)

--- a/src/core/Wyam.Testing/IO/TestFile.cs
+++ b/src/core/Wyam.Testing/IO/TestFile.cs
@@ -102,19 +102,23 @@ namespace Wyam.Testing.IO
         public Stream OpenWrite(bool createDirectory = true)
         {
             CreateDirectory(createDirectory, this);
-            return new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => new StringBuilder()));
+            return new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => y));
         }
 
         public Stream OpenAppend(bool createDirectory = true)
         {
             CreateDirectory(createDirectory, this);
-            return new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => y));
+            StringBuilderStream stream = new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => y));
+
+            // Start appending at the end of the stream.
+            stream.Position = stream.Length;
+            return stream;
         }
 
         public Stream Open(bool createDirectory = true)
         {
             CreateDirectory(createDirectory, this);
-            return new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => new StringBuilder()));
+            return new StringBuilderStream(_fileProvider.Files.AddOrUpdate(_path.FullPath, new StringBuilder(), (x, y) => y));
         }
     }
 }

--- a/tests/core/Wyam.Core.Tests/Modules/IO/WriteFilesFixture.cs
+++ b/tests/core/Wyam.Core.Tests/Modules/IO/WriteFilesFixture.cs
@@ -108,6 +108,28 @@ namespace Wyam.Core.Tests.Modules.IO
             }
 
             [Test]
+            public void ShouldTruncateOldFileOnWrite()
+            {
+                // Given
+                const string fileName = "test.txt";
+                const string oldContent = "TestTest";
+                const string newContent = "Test";
+
+                IFile fileMock = Engine.FileSystem.GetOutputFile(fileName);
+                fileMock.WriteAllText(oldContent);
+
+                WriteFiles writeFiles = new WriteFiles((x, y) => fileName);
+                IDocument[] inputs = { Context.GetDocument(Context.GetContentStream(newContent)) };
+
+                // When
+                writeFiles.Execute(inputs, Context).ToList();
+
+                // Then
+                IFile outputFile = Engine.FileSystem.GetOutputFile(fileName);
+                Assert.AreEqual(newContent, outputFile.ReadAllText());
+            }
+
+            [Test]
             public void ShouldReturnNullBasePathsForDotFiles()
             {
                 // Given


### PR DESCRIPTION
Consider the following case:

- The `noclean` directive is enabled.
- File `a` is written with the content `12345`.
- Wyam re-executes the pipeline.
- File `a` is written with the content `abc`.

In the above case, file `a` should have the content `abc`, however, at current, the file will have the content `abc45`. This is not intuitive to the end user as it is assumed that when the `noclean` directive is set, that files should be completely overridden while the output directory is not removed.

This pull does the following:
- WriteFiles will now truncate the output file when the output content is less than the size of the file (when append is disabled).
- Fixes the testing fixtures to reuse the original file content under test (rather than starting with a empty file on rewrites).
- Configures the test runner NCrunch for solution support. 

The following are breaking changes:
- Some modules may assume that WriteFiles will not truncate. 