### PR TITLE
Markdown UseExtensions(types) Broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config.wyam.hash
 config.wyam.dll
 *.ncrunch*
 .*crunch*.local.xml
+/_NCrunch_Wyam

--- a/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
+++ b/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
@@ -58,6 +58,29 @@ namespace Wyam.Markdown.Tests
             }
 
             [Test]
+            public void CanUseMultipleExternalExtensions()
+            {
+                const string input = @"![Alt text](/path/to/img.jpg)";
+                const string output = @"<p><img src=""/path/to/img.jpg"" class=""ui spaced image second"" alt=""Alt text"" /></p>";
+
+                TestExecutionContext context = new TestExecutionContext();
+                TestDocument document = new TestDocument(input);
+                Type[] o =
+                {
+                    typeof(ExternalMarkdownExtension),
+                    typeof(SecondExternalMarkdownExtension)
+                };
+                IEnumerable<Type> cast = o;
+                Markdown markdown = new Markdown().UseExtensions(cast);
+
+                // When
+                IList<IDocument> results = markdown.Execute(new[] { document }, context).ToList();
+
+                // Then
+                Assert.That(results.Select(x => x.Content.Trim()), Is.EquivalentTo(new[] { output }));
+            }
+
+            [Test]
             public void DoesNotRenderSpecialAttributesByDefault()
             {
                 // Given

--- a/tests/extensions/Wyam.Markdown.Tests/SecondExternalMarkdownExtension.cs
+++ b/tests/extensions/Wyam.Markdown.Tests/SecondExternalMarkdownExtension.cs
@@ -1,0 +1,36 @@
+﻿using Markdig;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Wyam.Markdown.Tests
+{
+    public class SecondExternalMarkdownExtension : IMarkdownExtension
+    {
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+            pipeline.DocumentProcessed -= PipelineOnDocumentProcessed;
+            pipeline.DocumentProcessed += PipelineOnDocumentProcessed;
+        }
+
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+        }
+
+        private static void PipelineOnDocumentProcessed(MarkdownDocument document)
+        {
+            foreach (var node in document.Descendants())
+            {
+                if (node is Inline)
+                {
+                    var link = node as LinkInline;
+                    if (link != null && link.IsImage)
+                    {
+                        link.GetAttributes().AddClass("second");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `UseExtensions` call within the Markdown module does not support multiple extensions. This is caused by the `AddIfNotAlready` method checking for the generic type added. Since the generic type is always of type `IMarkdownExtension` the method would fail to add any additional extensions.