### PR TITLE
Ability to Give Markdown Engine Extension Directly

### DIFF
--- a/src/extensions/Wyam.Markdown/Markdown.cs
+++ b/src/extensions/Wyam.Markdown/Markdown.cs
@@ -104,6 +104,24 @@ namespace Wyam.Markdown
         }
 
         /// <summary>
+        /// Includes a custom extension in the markdown processing given by a object implementing
+        /// the IMarkdownExtension interface.
+        /// </summary>
+        /// <param name="extension">A object that that implement <see cref="IMarkdownExtension"/>.</param>
+        /// <typeparam name="TExtension">The type of the extension to use.</typeparam>
+        /// <returns>The current module instance.</returns>
+        public Markdown UseExtension<TExtension>(TExtension extension)
+            where TExtension : IMarkdownExtension
+        {
+            if (extension != null)
+            {
+                _extensions.AddIfNotAlready(extension);
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Includes multiple custom extension in the markdown processing given by classes implementing
         /// the <see cref="IMarkdownExtension"/> interface.
         /// </summary>

--- a/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
+++ b/tests/extensions/Wyam.Markdown.Tests/MarkdownFixture.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using Markdig;
+
+using NSubstitute;
+
 using NUnit.Framework;
 using Wyam.Common.Documents;
 using Wyam.Common.Meta;
@@ -36,6 +41,21 @@ namespace Wyam.Markdown.Tests
 
                 // Then
                 Assert.That(results.Select(x => x.Content), Is.EquivalentTo(new[] { output }));
+            }
+
+            [Test]
+            public void CanUseExternalExtensionDirectly()
+            {
+                IMarkdownExtension mockExtension = Substitute.For<IMarkdownExtension>();
+                Markdown markdown = new Markdown().UseExtension(mockExtension);
+
+                // When
+                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+                markdown.Execute(new[] { new TestDocument(string.Empty) }, new TestExecutionContext()).ToList();  // Make sure to materialize the result list
+
+                // Then
+                // Setup will always be called during markdown pipeline setup.
+                mockExtension.Received().Setup(Arg.Any<MarkdownPipelineBuilder>());
             }
 
             [Test]


### PR DESCRIPTION
On my Wyam powered project, I need to give the Markdown engine some context from the Wyam pipeline for custom Markdown extensions (i.e. image placeholder sizing). This would require a shared instance between Wyam and the Markdown engine, however, Wyam currently isolates extension materialization with itself. This pull request adds the ability to give the Markdown engine an instance of an extension.