### PR TITLE
Fixed issue with month and day names in short/long date strings.

### DIFF
--- a/src/core/Wyam.Common/Execution/DateTimeCultureExtensions.cs
+++ b/src/core/Wyam.Common/Execution/DateTimeCultureExtensions.cs
@@ -42,8 +42,11 @@ namespace Wyam.Common.Execution
         /// <param name="targetCulture">The culture that should be used if the date display setting isn't provided. If the
         /// current culture is of the same family, then it will be used. If not, the specified target culture will be used.</param>
         /// <returns>A short date display string.</returns>
-        public static string ToShortDateString(this DateTime dateTime, IExecutionContext context, string targetCulture = "en-GB") =>
-            dateTime.ToString(context.GetDateTimeDisplayCulture(targetCulture).DateTimeFormat.ShortDatePattern);
+        public static string ToShortDateString(this DateTime dateTime, IExecutionContext context, string targetCulture = "en-GB")
+        {
+            CultureInfo culture = context.GetDateTimeDisplayCulture(targetCulture);
+            return dateTime.ToString(culture.DateTimeFormat.ShortDatePattern, culture);
+        }
 
         /// <summary>
         /// Gets a long date display string using the date display culture setting.
@@ -53,8 +56,11 @@ namespace Wyam.Common.Execution
         /// <param name="targetCulture">The culture that should be used if the date display setting isn't provided. If the
         /// current culture is of the same family, then it will be used. If not, the specified target culture will be used.</param>
         /// <returns>A long date display string.</returns>
-        public static string ToLongDateString(this DateTime dateTime, IExecutionContext context, string targetCulture = "en-GB") =>
-            dateTime.ToString(context.GetDateTimeDisplayCulture(targetCulture).DateTimeFormat.LongDatePattern);
+        public static string ToLongDateString(this DateTime dateTime, IExecutionContext context, string targetCulture = "en-GB")
+        {
+            CultureInfo culture = context.GetDateTimeDisplayCulture(targetCulture);
+            return dateTime.ToString(culture.DateTimeFormat.LongDatePattern, culture);
+        }
 
         /// <summary>
         /// Gets the <see cref="CultureInfo"/> for the date display culture.

--- a/tests/core/Wyam.Common.Tests/Util/DateTimeCultureExtensionsFixture.cs
+++ b/tests/core/Wyam.Common.Tests/Util/DateTimeCultureExtensionsFixture.cs
@@ -183,5 +183,29 @@ namespace Wyam.Common.Tests.Util
                 Assert.That(result, Is.EqualTo("mer. mars"));
             }
         }
+
+        public class ToLongDateStringTests : DateTimeCultureExtensionsFixture
+        {
+            [SetUp]
+            public void SetThreadCulture()
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            }
+
+            [Test]
+            public void IncludesNameOfGermanDayAndMonth()
+            {
+                // Given
+                TestExecutionContext context = new TestExecutionContext();
+                context.Settings[Keys.DateTimeDisplayCulture] = CultureInfo.GetCultureInfo("de-DE");
+                DateTime dateTime = new DateTime(2000, 3, 1);
+
+                // When
+                string result = dateTime.ToLongDateString(context);
+
+                // Then
+                Assert.That(result, Is.EqualTo("Mittwoch, 1. März 2000"));
+            }
+        }
     }
 }

--- a/tests/core/Wyam.Common.Tests/Util/DateTimeCultureExtensionsFixture.cs
+++ b/tests/core/Wyam.Common.Tests/Util/DateTimeCultureExtensionsFixture.cs
@@ -157,5 +157,31 @@ namespace Wyam.Common.Tests.Util
                 Assert.That(result, Is.EqualTo(CultureInfo.GetCultureInfo("en-GB")));
             }
         }
+
+        public class ToShortDateStringTests : DateTimeCultureExtensionsFixture
+        {
+            [SetUp]
+            public void SetThreadCulture()
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            }
+
+            [Test]
+            public void IncludesShortNameOfFrenchDayAndMonth()
+            {
+                // Given
+                TestExecutionContext context = new TestExecutionContext();
+                CultureInfo culture = (CultureInfo) CultureInfo.GetCultureInfo("fr-FR").Clone();
+                culture.DateTimeFormat.ShortDatePattern = "ddd MMM";
+                context.Settings[Keys.DateTimeDisplayCulture] = culture;
+                DateTime dateTime = new DateTime(2000, 3, 1);
+
+                // When
+                string result = dateTime.ToShortDateString(context);
+
+                // Then
+                Assert.That(result, Is.EqualTo("mer. mars"));
+            }
+        }
     }
 }


### PR DESCRIPTION
There was a problem in `ToShortDateString()` and `ToLongDateString()`. The culture was picked correctly, but only `ShortDatePattern` and `LongDatePattern` were used. The culture itself was not passed. Therefore, the *current* culture was used which led to wrong day and month names.