### PR TITLE
Fix to address issue 662 - https://github.com/Wyamio/Wyam/issues/662

### DIFF
--- a/src/core/Wyam.Configuration/NuGet/SourceRepositoryProvider.cs
+++ b/src/core/Wyam.Configuration/NuGet/SourceRepositoryProvider.cs
@@ -18,11 +18,6 @@ namespace Wyam.Configuration.NuGet
     /// </summary>
     internal class SourceRepositoryProvider : ISourceRepositoryProvider
     {
-        private static readonly string[] DefaultSources =
-        {
-            "https://api.nuget.org/v3/index.json"
-        };
-
         private readonly List<SourceRepository> _defaultRepositories = new List<SourceRepository>();
         private readonly ConcurrentDictionary<PackageSource, SourceRepository> _repositoryCache
             = new ConcurrentDictionary<PackageSource, SourceRepository>();
@@ -37,12 +32,6 @@ namespace Wyam.Configuration.NuGet
             // Add the v3 provider as default
             _resourceProviders = new List<Lazy<INuGetResourceProvider>>();
             _resourceProviders.AddRange(Repository.Provider.GetCoreV3());
-
-            // Add the default sources
-            foreach (string defaultSource in DefaultSources)
-            {
-                AddDefaultRepository(defaultSource);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
There are build systems that block access to "outside" NuGet sources.
Therefore, the hard-coded DefaultSources list in
SourceRepositoryProvider.cs presents a problem when trying to generate
documentation. There seems to be no way to opt out of using
"https://api.nuget.org/v3/index.json".
This fix removes this hard-coded value and leaves the decision to the
user via their NuGet.config setup or their WyamSettings specifications
(setting of NugetSources and UseGlobalSources).