### PR TITLE
Fix blog recipe documentation.

### DIFF
--- a/src/recipes/Wyam.Blog/BlogKeys.cs
+++ b/src/recipes/Wyam.Blog/BlogKeys.cs
@@ -229,7 +229,7 @@ namespace Wyam.Blog
         public const string Excerpt = nameof(Excerpt);
 
         /// <summary>
-        /// Set to <c>true</c> to hide a particular page from the top-level navigation bar.
+        /// Set to <c>false</c> to hide a particular page from the top-level navigation bar.
         /// </summary>
         /// <type><see cref="bool"/></type>
         public const string ShowInNavbar = nameof(ShowInNavbar);


### PR DESCRIPTION
Default value for ShowInNavbar seems to be "true" (the aboutme page is displayed in the navigation bar). You need to set this property to false to actually hide a page from the navigation bar.