### PR TITLE
 Add generation of autolinks for embedded generic types

### DIFF
--- a/src/extensions/Wyam.Html/AutoLink.cs
+++ b/src/extensions/Wyam.Html/AutoLink.cs
@@ -177,9 +177,11 @@ namespace Wyam.Html
             });
         }
 
-        private bool ReplaceStrings(IText text, IDictionary<string, string> map, out string newText)
+        private bool ReplaceStrings(IText text, IDictionary<string, string> map, out string newText) => ReplaceStrings(text.Text, map, out newText);
+
+        private bool ReplaceStrings(string text, IDictionary<string, string> map, out string newText)
         {
-            string s = WebUtility.HtmlEncode(text.Text);  // The text content is unencoded so we need to reencode it before performing replacements
+            string s = WebUtility.HtmlEncode(text);  // The text content is unencoded so we need to reencode it before performing replacements
             Trie<char> lookup = new Trie<char>(map.Keys);
             StringBuilder builder = new StringBuilder();
             int lastIdx = -1;
@@ -237,6 +239,13 @@ namespace Wyam.Html
                 lastNode = lookup.Root;
             }
             newText = replaced ? builder.ToString() : string.Empty;
+            if (!replaced && text.Contains("<") && text.EndsWith(">"))
+            {
+                var splittedText = text.Split(new[] { '<' }, 2);
+                replaced = ReplaceStrings(splittedText[1].Remove(splittedText[1].Length - 1), map, out string replacedText);
+                newText = replaced ? $"{splittedText[0]}&lt;{replacedText}&gt;" : string.Empty;
+            }
+
             return replaced;
         }
 

--- a/src/extensions/Wyam.Html/AutoLink.cs
+++ b/src/extensions/Wyam.Html/AutoLink.cs
@@ -239,6 +239,9 @@ namespace Wyam.Html
                 lastNode = lookup.Root;
             }
             newText = replaced ? builder.ToString() : string.Empty;
+
+            // Special case of embedded generic types (like Foo<Foo>), the generic parameter
+            // is extracted and tested if no match was found.
             if (!replaced && text.Contains("<") && text.EndsWith(">"))
             {
                 var splittedText = text.Split(new[] { '<' }, 2);


### PR DESCRIPTION
As I said in https://github.com/Wyamio/Wyam/issues/674#issuecomment-395141531, I'm not 100% happy with the solution but it works and does not seem to break things. I considered adding a check for `_matchOnlyWholeWord` (equal to `true`) and/or `_querySelector` (equal to `code`) to restrict the case to the specific recipe usage but I wasn't sure that it was a good idea.

Preview:
![](https://user-images.githubusercontent.com/10998921/41053366-a0349478-69bb-11e8-9a59-45cd96af3262.png)
