### PR TITLE
fix for 'unrecognized expression' syntax error exception in the Stellar blog theme

### DIFF
--- a/themes/Blog/Stellar/assets/js/main.js
+++ b/themes/Blog/Stellar/assets/js/main.js
@@ -89,7 +89,7 @@
 
 							var	$this = $(this),
 								id = $this.attr('href'),
-								$section = $(id);
+								$section = $(id.replace('/',''));
 
 							// No section for this link? Bail.
 								if ($section.length < 1)


### PR DESCRIPTION
There's an extremely annoying error on the Stellar theme. When running it thru `wyam.exe -p` the console reads:
```
Uncaught Error: Syntax error, unrecognized expression: /
    at Function.ga.error (jquery.min.js:2)
    at ga.tokenize (jquery.min.js:2)
    at ga.select (jquery.min.js:2)
    at Function.ga [as find] (jquery.min.js:2)
    at m.fn.init.find (jquery.min.js:2)
    at new m.fn.init (jquery.min.js:2)
    at m (jquery.min.js:2)
    at HTMLAnchorElement.<anonymous> (main.js:93)
    at Function.each (jquery.min.js:2)
    at m.fn.init.each (jquery.min.js:2)
```
I thought it was the google analytics code, but no. It happens to be a piece of code in the `main.js` file. so I fixed it. I don't see any negative side-effect.

Let me know if it's better to create an issue before this PR. I thought It was too simple and small to create one.