### PR TITLE
Add handling for missing leading forward slash

### DIFF
--- a/themes/Docs/Samson/Shared/_Infobar.cshtml
+++ b/themes/Docs/Samson/Shared/_Infobar.cshtml
@@ -3,6 +3,10 @@
     FilePath editFilePath = Model.FilePath(Wyam.Web.WebKeys.EditFilePath);
     if(!string.IsNullOrWhiteSpace(baseEditUrl) && editFilePath != null)
     {
+        if (!baseEditUrl[baseEditUrl.Length - 1].equals('/'))
+        {
+            baseEditUrl += "/";
+        }
         string editUrl = baseEditUrl + editFilePath.FullPath;
         <div><p><a href="@editUrl"><i class="fa fa-pencil-square" aria-hidden="true"></i> Edit Content</a></p></div>
     }


### PR DESCRIPTION
If `DocsKeys.BaseEditUrl` in `config.wyam` is missing a forward slash at the end, a malformed edit address is produced.

For example,

`Settings[DocsKeys.BaseEditUrl] = "https://code.luzfaltex.com"`

Will result in a url like:

`https://code.luzfaltex.comlegal/privacy/index.md`

This adds a quick check for the existence of a `/` at the end of the url and appends it if absent.