### PR TITLE
adding support for Source Code link for the NuGet gallery

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -207,6 +207,10 @@ Task("Create-Theme-Packages")
                 Tags = new [] { "Wyam", "Theme", "Static", "StaticContent", "StaticSite" },
                 RequireLicenseAcceptance = false,
                 Symbols = false,
+                Repository = new NuGetRepository {
+                    Type = "git",
+                    Url = "https://github.com/Wyamio/Wyam.git"
+                },
                 Files = new []
                 {
                     new NuSpecContent 

--- a/src/clients/Wyam/Wyam.nuspec
+++ b/src/clients/Wyam/Wyam.nuspec
@@ -9,6 +9,7 @@
     <licenseUrl>https://github.com/Wyamio/Wyam/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://wyam.io/Content/images/logo-square-64.png</iconUrl>
     <projectUrl>https://wyam.io</projectUrl>
+    <repository type="git" url="https://github.com/Wyamio/Wyam.git" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Wyam is a simple to use, highly modular, and extremely configurable static content generator. This is a tools package that contains the Wyam CLI.</description>
     <copyright>Copyright 2017</copyright>

--- a/src/extensions/Wyam.All/Wyam.All.nuspec
+++ b/src/extensions/Wyam.All/Wyam.All.nuspec
@@ -9,6 +9,7 @@
     <licenseUrl>https://github.com/Wyamio/Wyam/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://wyam.io/Content/images/logo-square-64.png</iconUrl>
     <projectUrl>https://wyam.io</projectUrl>
+    <repository type="git" url="https://github.com/Wyamio/Wyam.git" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Wyam is a simple to use, highly modular, and extremely configurable static content generator. This library contains references to all official modules and can be used to add them all at once.</description>
     <copyright>Copyright 2017</copyright>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.23.0" />
+    <package id="Cake" version="0.30.0" />
     <package id="NUnit.Console" version="3.0.1" />
     <package id="Octokit" version="0.17.0" />
     <package id="Squirrel.Windows" version="1.4.0" />


### PR DESCRIPTION
So this changes the build step for the Themes within Cake to have support for GitHub links directly.

All other packages and extensions uses `nuspec` files so I inserted the link directly in there.

So this fixes #705