### PR TITLE
Ability to configure blog title in docs recipe

### DIFF
--- a/src/recipes/Wyam.Docs/Docs.cs
+++ b/src/recipes/Wyam.Docs/Docs.cs
@@ -60,6 +60,7 @@ namespace Wyam.Docs
     /// <metadata cref="DocsKeys.BlogAtomPath" usage="Setting" />
     /// <metadata cref="DocsKeys.BlogRdfPath" usage="Setting" />
     /// <metadata cref="DocsKeys.BlogPath" usage="Setting" />
+    /// <metadata cref="DocsKeys.BlogTitle" usage="Setting" />
     /// <metadata cref="DocsKeys.ValidateAbsoluteLinks" usage="Setting" />
     /// <metadata cref="DocsKeys.ValidateRelativeLinks" usage="Setting" />
     /// <metadata cref="DocsKeys.ValidateLinksAsError" usage="Setting" />
@@ -162,7 +163,7 @@ namespace Wyam.Docs
                 TemplateFile = ctx => "_BlogIndex.cshtml",
                 Layout = "/_BlogLayout.cshtml",
                 PageSize = ctx => ctx.Get(DocsKeys.BlogPageSize, int.MaxValue),
-                Title = (doc, ctx) => "Blog",
+                Title = (doc, ctx) => ctx.Get(DocsKeys.BlogTitle, "Blog"),
                 RelativePath = (doc, ctx) => $"{ctx.DirectoryPath(DocsKeys.BlogPath, ".").FullPath}"
             });
 
@@ -363,6 +364,7 @@ namespace Wyam.Docs
             engine.Settings[DocsKeys.MetaRefreshRedirects] = true;
             engine.Settings[DocsKeys.AutoLinkTypes] = true;
             engine.Settings[DocsKeys.BlogPath] = "blog";
+            engine.Settings[DocsKeys.BlogTitle] = "Blog";
             engine.Settings[DocsKeys.BlogPageSize] = 5;
             engine.Settings[DocsKeys.CategoryPageSize] = 5;
             engine.Settings[DocsKeys.TagPageSize] = 5;

--- a/src/recipes/Wyam.Docs/DocsKeys.cs
+++ b/src/recipes/Wyam.Docs/DocsKeys.cs
@@ -230,6 +230,13 @@ namespace Wyam.Docs
         public const string BlogPath = nameof(BlogPath);
 
         /// <summary>
+        /// Specifies the blog title.
+        /// The default value is <c>Blog</c>.
+        /// </summary>
+        /// <type><see cref="string"/></type>
+        public const string BlogTitle = nameof(BlogTitle);
+
+        /// <summary>
         /// Controls the parent path where API docs are placed. The default is "api".
         /// </summary>
         /// <type><see cref="DirectoryPath"/> or <see cref="string"/></type>

--- a/themes/Docs/Samson/_Navbar.cshtml
+++ b/themes/Docs/Samson/_Navbar.cshtml
@@ -9,7 +9,7 @@
         .ToList();
     if(Documents[Docs.BlogPosts].Any())
     {
-        pages.Add(Tuple.Create("Blog", Context.GetLink(Context.String(DocsKeys.BlogPath))));
+        pages.Add(Tuple.Create(Context.String(DocsKeys.BlogTitle), Context.GetLink(Context.String(DocsKeys.BlogPath))));
     }
     if(Documents[Docs.Api].Any())
     {


### PR DESCRIPTION
You can change the blog path but could not change the blog title. This can create a slight inconsistency.

This pull request allows the blog path and title to be changed without needing to override the default docs theme.

Use case:
Current Implementation:
BlogPath = ReleaseNotes
BlogTitle = Blog

Proposed Implementation:
BlogPath = ReleaseNotes
BlogTitle = Release Notes