### PR TITLE
Fix BookSiteKeys.BookImage references in the theme so they don't assume the root directory.

### DIFF
--- a/themes/BookSite/Velocity/_Footer.cshtml
+++ b/themes/BookSite/Velocity/_Footer.cshtml
@@ -1,7 +1,7 @@
 <div id="footer" class="container">    
 <div class="row">
     <div class="2u 12u(mobile) image">
-        <img src="@Context.String(BookSiteKeys.BookImage)">
+        <img src="@Context.GetLink(Context.String(BookSiteKeys.BookImage))">
     </div>
     <div class="10u 12u(mobile)">
         <h2>@Context.String(BookSiteKeys.Title)</h2>        

--- a/themes/BookSite/Velocity/_Introduction.cshtml
+++ b/themes/BookSite/Velocity/_Introduction.cshtml
@@ -3,7 +3,7 @@
     <section id="intro" class="container">
 	<div class="row">
 	    <div class="4u 12u(mobile) image">
-		<img src="@Context.String(BookSiteKeys.BookImage)">
+		<img src="@Context.GetLink(Context.String(BookSiteKeys.BookImage))">
 	    </div>
 	    <div class="8u 12u(mobile)">
 		@if(Context.ContainsKey(BookSiteKeys.Description))

--- a/themes/BookSite/Velocity/_Layout.cshtml
+++ b/themes/BookSite/Velocity/_Layout.cshtml
@@ -36,7 +36,7 @@
 					<div id="sidebar">
 						<section class="box">
 							<div class="image">
-								<img src="@Context.String(BookSiteKeys.BookImage)">
+								<img src="@Context.GetLink(Context.String(BookSiteKeys.BookImage))">
 							</div>
 							<header>
 								<h2>@Context.String(BookSiteKeys.Title)</h2>        


### PR DESCRIPTION
The default theme references BookKeys.Image as a basic string, which works fine until you try to use it in conjunction with Keys.LinkRoot. In that case the configuration key either needs to have the entire path (including the Keys.LinkRoot portion) or else the theme needs modified to use Context.GetLink() so it prepends the LinkRoot.