### PR TITLE
Allow the If indexer to be accessed without casting

### DIFF
--- a/src/core/Wyam.Core/Modules/Control/If.cs
+++ b/src/core/Wyam.Core/Modules/Control/If.cs
@@ -165,7 +165,7 @@ namespace Wyam.Core.Modules.Control
         public bool IsReadOnly => ((IList<IfCondition>)_conditions).IsReadOnly;
 
         /// <inheritdoc />
-        IfCondition IList<IfCondition>.this[int index]
+        public IfCondition this[int index]
         {
             get => _conditions[index];
             set => _conditions[index] = value;


### PR DESCRIPTION
`If` implements IList<IfCondition>, but the indexer is explicitly implemented. So instead of `Pipelines["TagIndex"].GetFirst<If>()[0]`, it needs to be cast first: `((IList<IfCondition>)Pipelines["TagIndex"].GetFirst<If>())[0]`.

Since the other members of IList aren't explicitly implemented and the release notes indicate the first way is expected to work, I've changed it to implement `this` implicitly instead.