### PR TITLE
Make the globber case insensitive if the current file system is

### DIFF
--- a/src/core/Wyam.Core/Wyam.Core.csproj
+++ b/src/core/Wyam.Core/Wyam.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="2.3.0" />
     <PackageReference Include="jint" Version="2.10.3" />
     <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />


### PR DESCRIPTION
This fixes issues such as having globs like "../wyamio/wyam/**/*.dll" if on windows it's also WyamIO for the folder.

The approach generates a temporary file guid, does both lower case/upper case versions of the file, if they both exist then it considers the file system case insensitive.

Also updated the Microsoft.Extensions.FileSystemGlobbing package.