### PR TITLE
Fix URL absolute link validation

### DIFF
--- a/src/extensions/Wyam.Html/ValidateLinks.cs
+++ b/src/extensions/Wyam.Html/ValidateLinks.cs
@@ -1,15 +1,19 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Dom.Html;
 using AngleSharp.Parser.Html;
+using Polly;
+using Polly.Bulkhead;
+using Polly.Retry;
+using Wyam.Common.Documents;
 using Wyam.Common.Execution;
 using Wyam.Common.IO;
 using Wyam.Common.Meta;
@@ -30,6 +34,12 @@ namespace Wyam.Html
     /// <category>Input/Output</category>
     public class ValidateLinks : IModule
     {
+        private const int MaxAbsoluteLinkRetry = 5;
+        private const HttpStatusCode TooManyRequests = (HttpStatusCode)429;
+
+        // Cache the HttpClient as per recommended advice. Since this is short lived we don't have to worry about DNS issues.
+        private static HttpClient _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
         private bool _validateAbsoluteLinks;
         private bool _validateRelativeLinks = true;
         private bool _asError;
@@ -92,34 +102,38 @@ namespace Wyam.Html
             HtmlParser parser = new HtmlParser();
             context.ParallelForEach(inputs, input => GatherLinks(input, parser, links));
 
-            // Perform validation
-            Parallel.ForEach(links, link =>
-            {
-                // Attempt to parse the URI
-                if (!Uri.TryCreate(link.Key, UriKind.RelativeOrAbsolute, out Uri uri))
+            // This policy will limit the number of executing link validations.
+            // Limit the amount of concurrent link checks to avoid overwhelming servers.
+            Task[] tasks = links.Select(
+                async link =>
                 {
-                    AddOrUpdateFailure(link.Value, failures);
-                }
+                    // Attempt to parse the URI
+                    if (!Uri.TryCreate(link.Key, UriKind.RelativeOrAbsolute, out Uri uri))
+                    {
+                        AddOrUpdateFailure(link.Value, failures);
+                    }
 
-                // Adjustment for double-slash link prefix which means use http:// or https:// depending on current protocol
-                // The Uri class treats these as relative, but they're really absolute
-                if (uri.ToString().StartsWith("//") && !Uri.TryCreate($"http:{link.Key}", UriKind.Absolute, out uri))
-                {
-                    AddOrUpdateFailure(link.Value, failures);
-                }
+                    // Adjustment for double-slash link prefix which means use http:// or https:// depending on current protocol
+                    // The Uri class treats these as relative, but they're really absolute
+                    if (uri.ToString().StartsWith("//") && !Uri.TryCreate($"http:{link.Key}", UriKind.Absolute, out uri))
+                    {
+                        AddOrUpdateFailure(link.Value, failures);
+                    }
 
-                // Relative
-                if (!uri.IsAbsoluteUri && _validateRelativeLinks && !ValidateRelativeLink(uri, context))
-                {
-                    AddOrUpdateFailure(link.Value, failures);
-                }
+                    // Relative
+                    if (!uri.IsAbsoluteUri && _validateRelativeLinks && !(await ValidateRelativeLink(uri, context).ConfigureAwait(false)))
+                    {
+                        AddOrUpdateFailure(link.Value, failures);
+                    }
 
-                // Absolute
-                if (uri.IsAbsoluteUri && _validateAbsoluteLinks && !ValidateAbsoluteLink(uri))
-                {
-                    AddOrUpdateFailure(link.Value, failures);
-                }
-            });
+                    // Absolute
+                    if (uri.IsAbsoluteUri && _validateAbsoluteLinks && !(await ValidateAbsoluteLink(uri).ConfigureAwait(false)))
+                    {
+                        AddOrUpdateFailure(link.Value, failures);
+                    }
+                }).ToArray();
+
+            Task.WaitAll(tasks);
 
             // Report failures
             if (failures.Count > 0)
@@ -169,7 +183,7 @@ namespace Wyam.Html
         }
 
         // Internal for testing
-        internal static bool ValidateRelativeLink(Uri uri, IExecutionContext context)
+        internal static async Task<bool> ValidateRelativeLink(Uri uri, IExecutionContext context)
         {
             List<FilePath> checkPaths = new List<FilePath>();
 
@@ -238,7 +252,7 @@ namespace Wyam.Html
             // Check the absolute URL just in case the user is using some sort of CNAME or something.
             if (Uri.TryCreate(context.GetLink() + uri, UriKind.Absolute, out Uri absoluteCheckUri))
             {
-                return ValidateAbsoluteLink(absoluteCheckUri);
+                return await ValidateAbsoluteLink(absoluteCheckUri).ConfigureAwait(false);
             }
 
             Trace.Verbose($"Validation failure for relative link {uri}: could not find output file at any of {string.Join(", ", checkPaths.Select(x => x.FullPath))}");
@@ -246,7 +260,7 @@ namespace Wyam.Html
         }
 
         // Internal for testing
-        internal static bool ValidateAbsoluteLink(Uri uri)
+        internal static async Task<bool> ValidateAbsoluteLink(Uri uri)
         {
             // If this is a mailto: link, it's sufficient just that it passed the Uri validation.
             if (uri.Scheme == Uri.UriSchemeMailto)
@@ -255,7 +269,7 @@ namespace Wyam.Html
             }
 
             // Perform request as HEAD
-            bool result = ValidateAbsoluteLink(uri, "HEAD");
+            bool result = await ValidateAbsoluteLink(uri, HttpMethod.Head).ConfigureAwait(false);
 
             if (result)
             {
@@ -263,68 +277,53 @@ namespace Wyam.Html
             }
 
             // Try one more time as GET
-            return ValidateAbsoluteLink(uri, "GET");
+            return await ValidateAbsoluteLink(uri, HttpMethod.Get).ConfigureAwait(false);
         }
 
-        private static bool ValidateAbsoluteLink(Uri uri, string method)
+        private static async Task<bool> ValidateAbsoluteLink(Uri uri, HttpMethod method)
         {
-            // Create a request
-            HttpWebRequest request = null;
+            // Retry with exponential backoff links. This helps with websites like GitHub that will give us a 429 -- TooManyRequests.
+            RetryPolicy<HttpResponseMessage> retryPolicy = Policy
+                .Handle<HttpRequestException>()
+                .OrResult<HttpResponseMessage>(r => r.StatusCode == TooManyRequests)
+                .WaitAndRetryAsync(MaxAbsoluteLinkRetry, attempt => TimeSpan.FromSeconds(0.1 * Math.Pow(2, attempt)));
+
             try
             {
-                request = WebRequest.CreateHttp(uri);
-                request.Method = method;
+                HttpResponseMessage response = await retryPolicy.ExecuteAsync(() => _httpClient.SendAsync(new HttpRequestMessage(method, uri))).ConfigureAwait(false);
 
-                // Set request properties
-                request.Timeout = 60000; // 60 seconds
-            }
-            catch (NotSupportedException ex)
-            {
-                Trace.Warning($"Skipping absolute link {uri}: {ex.Message}");
-                return true;
-            }
-
-            if (request == null)
-            {
-                Trace.Warning($"Skipping absolute link {uri}: only HTTP/HTTPS links are validated");
-                return true;
-            }
-
-            HttpWebResponse response = null;
-            try
-            {
-                try
+                // Even with exponential backoff we have TooManyRequests, just skip, since we have to assume it's valid.
+                if (response.StatusCode == TooManyRequests)
                 {
-                    response = (HttpWebResponse)request.GetResponse();
-                }
-                catch (WebException)
-                {
-                    response = null;
-                }
-                catch (OperationCanceledException)
-                {
-                    response = null;
+                    Trace.Verbose($"Skipping absolute link {uri}: too many requests have been issued so can't reliably test.");
+                    return true;
                 }
 
-                // Check the status code
-                if (response != null)
+                // We don't use IsSuccessStatusCode, we consider in this case 300's valid.
+                if (response.StatusCode >= HttpStatusCode.BadRequest)
                 {
-                    if ((int)response.StatusCode >= 100 && (int)response.StatusCode < 400)
-                    {
-                        Trace.Verbose($"Validated absolute link {method} {uri}: returned status code {(int)response.StatusCode} {response.StatusCode}");
-                        return true;
-                    }
-
                     Trace.Verbose($"Validation failure for absolute link {method} {uri}: returned status code {(int)response.StatusCode} {response.StatusCode}");
                     return false;
                 }
 
-                Trace.Verbose($"Validation failure for absolute link {method} {uri}: failed to receive a response.");
-                return false;
+                // We don't bother disposing of the response in this case. Due to advice from here: https://stackoverflow.com/questions/15705092/do-httpclient-and-httpclienthandler-have-to-be-disposed
+                Trace.Verbose($"Validation success for absolute link {method} {uri}: returned status code {(int)response.StatusCode} {response.StatusCode}");
+                return true;
             }
-            finally
+            catch (TaskCanceledException ex)
             {
-                response?.Close();
+                Trace.Verbose($"Skipping absolute link {method} {uri} due to timeout: {ex}.");
+                return true;
+            }
+            catch (ArgumentException ex)
+            {
+                Trace.Verbose($"Skipping absolute link {method} {uri} due to invalid uri: {ex}.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Trace.Verbose($"Skipping absolute link {method} {uri} due to unknown error: {ex}.");
+                return true;
             }
         }
 

--- a/src/extensions/Wyam.Html/Wyam.Html.csproj
+++ b/src/extensions/Wyam.Html/Wyam.Html.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.10" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+    <PackageReference Include="Polly" Version="6.1.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/src/extensions/Wyam.Html/Wyam.Html.csproj
+++ b/src/extensions/Wyam.Html/Wyam.Html.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.10" />
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/extensions/Wyam.Html.Tests/ValidateLinksFixture.cs
+++ b/tests/extensions/Wyam.Html.Tests/ValidateLinksFixture.cs
@@ -32,8 +32,8 @@ namespace Wyam.Html.Tests
                 // Given
                 IDocument document = new TestDocument($"<html><head></head><body>{tag}</body></html>");
                 HtmlParser parser = new HtmlParser();
-                ConcurrentDictionary<string, ConcurrentBag<Tuple<FilePath, string>>> links =
-                    new ConcurrentDictionary<string, ConcurrentBag<Tuple<FilePath, string>>>();
+                ConcurrentDictionary<string, ConcurrentBag<(string source, string outerHtml)>> links =
+                    new ConcurrentDictionary<string, ConcurrentBag<(string source, string outerHtml)>>();
 
                 // When
                 ValidateLinks.GatherLinks(document, parser, links);
@@ -53,8 +53,8 @@ namespace Wyam.Html.Tests
                 // Given
                 IDocument document = new TestDocument($"<html><head>{tag}</head><body></body></html>");
                 HtmlParser parser = new HtmlParser();
-                ConcurrentDictionary<string, ConcurrentBag<Tuple<FilePath, string>>> links =
-                    new ConcurrentDictionary<string, ConcurrentBag<Tuple<FilePath, string>>>();
+                ConcurrentDictionary<string, ConcurrentBag<(string source, string outerHtml)>> links =
+                    new ConcurrentDictionary<string, ConcurrentBag<(string source, string outerHtml)>>();
 
                 // When
                 ValidateLinks.GatherLinks(document, parser, links);


### PR DESCRIPTION
* Absolute validation would fail if it would fall through and do Get notification with a InvalidOperationException, now fixed to re-create the WebRequest. (not sure if Get checking is really needed in theory HEAD should always exist).
* Now using ValueTuple to avoid the heap allocation hit
* Was getting a bunch of mailto URL warnings. Now skip those since we don't want to do a webrequest against them.
* Was getting empty FilePath's, now using SourceString() to get guaranteed output
* The warnings inside the Validation methods (that we later add to the collection if there is failure) were spitting out Warning's rather than verbose, so we were getting a lot of duplication of warnings/error spitting out. Now using Verbose except for skipped unknown url types.