### PR TITLE
Add documentation on how to use Include shortcode

### DIFF
--- a/src/core/Wyam.Core/Modules/IO/Include.cs
+++ b/src/core/Wyam.Core/Modules/IO/Include.cs
@@ -14,12 +14,17 @@ namespace Wyam.Core.Modules.IO
     /// Processes include statements to include files from the file system.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This module will look for include statements in the content of each document and
     /// will replace them with the content of the requested file from the file system.
     /// Include statements take the form <c>^"folder/file.ext"</c>. The given path will be
     /// converted to a <see cref="FilePath"/> and can be absolute or relative. If relative,
     /// it should be relative to the document source. You can escape the include syntax by
     /// prefixing the <c>^</c> with a forward slash <c>\</c>.
+    /// </para>
+    /// <para>
+    /// Since Wyam version 2.2.0, you can also use <see cref="Shortcodes.IO.Include"/> shortcode
+    /// </para>
     /// </remarks>
     /// <category>Input/Output</category>
     public class Include : IModule

--- a/src/core/Wyam.Core/Shortcodes/IO/Include.cs
+++ b/src/core/Wyam.Core/Shortcodes/IO/Include.cs
@@ -19,6 +19,22 @@ namespace Wyam.Core.Shortcodes.IO
     /// If the file does not exist nothing will be rendered.
     /// </remarks>
     /// <parameter>The path to the file to include.</parameter>
+    /// <example>
+    /// <para>Example usage to show the contents of test-include.html in the output</para>
+    /// <para>
+    /// <code>
+    /// &lt;?# Include "test-include.html" /?&gt;
+    /// </code>
+    /// </para>
+    /// <para>
+    /// If the included file contains Markdown syntax, you can even include it before the Markdown engine runs with a slight syntax change:
+    /// </para>
+    /// <para>
+    /// <code>
+    /// &lt;?! Include "test-include.md" /?&gt;?
+    /// </code>
+    /// </para>
+    /// </example>
     public class Include : IShortcode
     {
         private FilePath _sourcePath;


### PR DESCRIPTION
As we discussed on [Stack Overlow](https://stackoverflow.com/questions/55548043/how-can-i-include-other-files-in-a-post-in-wyam/55592765?noredirect=1#comment97954862_55592765).

I have included some documentation on how to use the Include shortcodes to both the Include shortcode class and the Include module class. I have not been able to run a build yet, so I'm not sure whether the docs will turn out right. 