### PR TITLE
Add resolve NuGet using TargetFramework

### DIFF
--- a/src/core/Wyam.Configuration/NuGet/PackageInstaller.cs
+++ b/src/core/Wyam.Configuration/NuGet/PackageInstaller.cs
@@ -207,7 +207,7 @@ namespace Wyam.Configuration.NuGet
                     }
                     catch (Exception ex)
                     {
-                        Trace.Verbose($"Exception while installing packages: {(ex is AggregateException ? string.Join("; ", ((AggregateException)ex).InnerExceptions.Select(x => x.Message)) : ex.Message)}");
+                        Trace.Verbose($"Exception while installing packages: {(ex is AggregateException aex ? aex.Flatten() : ex)}");
                         Trace.Warning("Error while installing packages, attempting without remote repositories");
                         InstallPackages(packageManager, Array.Empty<SourceRepository>(), installedPackages);
                     }
@@ -230,7 +230,7 @@ namespace Wyam.Configuration.NuGet
         {
             foreach (Package package in _packages.Values)
             {
-                package.Install(installationRepositories, installedPackages, packageManager).Wait();
+                package.Install(installationRepositories, installedPackages, packageManager).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/core/Wyam.Configuration/NuGet/WyamFolderNuGetProject.cs
+++ b/src/core/Wyam.Configuration/NuGet/WyamFolderNuGetProject.cs
@@ -33,6 +33,7 @@ namespace Wyam.Configuration.NuGet
             _assemblyLoader = assemblyLoader;
             _currentFramework = currentFramework;
             _installedPackages = installedPackages;
+            InternalMetadata[NuGetProjectMetadataKeys.TargetFramework] = _currentFramework;
         }
 
         // This gets called for every package install, including dependencies, and is our only chance to handle dependency PackageIdentity instances


### PR DESCRIPTION
* This change will change package resolver to not use any moniker but instead target framework.

```diff
- Attempting to gather dependency information for package 'Wyam.Docs.2.2.4' with respect to project 'C:/projects/website-8e3xp/packages', targeting 'Any,Version=v0.0'
+ Attempting to gather dependency information for package 'Wyam.Docs.2.2.4' with respect to project 'C:/projects/website-8e3xp/packages', targeting '.NETCoreApp,Version=v2.1'
```

Also a bit out of scope, so could revert if you want

* Flattened exceptions when installing packages for error message without duplicates. ToString more complete error messages.
* Address potential async issue 