### PR TITLE
Use latest version of Markdig

### DIFF
--- a/src/extensions/Wyam.Markdown/Wyam.Markdown.csproj
+++ b/src/extensions/Wyam.Markdown/Wyam.Markdown.csproj
@@ -12,6 +12,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.15.4" />
+    <PackageReference Include="Markdig" Version="0.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We're exploring using Wyam in dotnet try, which also uses Markdig. Markdig made a breaking change by changing the signature of `MarkdownParser.Parse` to add an [optional parameter ](https://github.com/lunet-io/markdig/blob/ea6592b773def5e430b3af7c08ff774e9dc94c3e/src/Markdig/Parsers/MarkdownParser.cs#L74). dotnet try uses 0.17.0 so we get MissingMethodExceptions.

This change takes the latest release of markdig.