### PR TITLE
Rendering blog tags in the Docs recipe

### DIFF
--- a/themes/Docs/Samson/Shared/_BlogPostFooter.cshtml
+++ b/themes/Docs/Samson/Shared/_BlogPostFooter.cshtml
@@ -1,0 +1,17 @@
+@model IDocument
+
+@{
+    var allTags = Model.Get<List<string>>(DocsKeys.Tags);
+    if (allTags != null && allTags.Any()) {
+        <hr />
+        <text>Tags:</text>
+        <ul class="inline">
+            @foreach(string tag in allTags.Distinct().OrderBy(x => x))
+            {
+                string link = tag.Replace(" ", "-").Replace("'", string.Empty);
+                <li><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/tag/{link}")">@tag</a></li>
+            }
+        </ul>
+        <hr />
+    }
+}

--- a/themes/Docs/Samson/_BlogLayout.cshtml
+++ b/themes/Docs/Samson/_BlogLayout.cshtml
@@ -5,7 +5,7 @@
 @section Sidebar {
     @if(Documents[Docs.BlogPosts].Any(x => x.ContainsKey(DocsKeys.Category)))
     {
-        <li class="header"><i class="fa fa-bookmark"></i> Categories</li>    
+        <li class="header"><i class="fa fa-bookmark"></i> Categories</li>
         @foreach(string category in Documents[Docs.BlogPosts]
             .Select(x => x.String(DocsKeys.Category))
             .Distinct()
@@ -16,30 +16,53 @@
             <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/{link}")">@category</a></li>
         }
     }
-    
-    <li class="header"><i class="fa fa-calendar"></i> Archive</li>    
-    @foreach(DateTime published in Documents[Docs.BlogPosts]
-        .Select(x => x.Get<DateTime>(DocsKeys.Published))
-        .Select(x => new DateTime(x.Year, x.Month, 1))
-        .Distinct()
-        .OrderByDescending(x => x))
-    {
-        string link = published.ToString("yyyy/MM");
-        string selected = Model.String(Keys.RelativeFilePath).StartsWith($"{Context.String(DocsKeys.BlogPath)}/archive/{link}/") ? "selected" : null;
-        <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/archive/{link}")">@(published.ToString("MMMM, yyyy"))</a></li>
-    }
-    
+    @Html.Raw("</ul>") @* This ul is opened outside section *@
+
+    <ul class="sidebar-menu">
+        <li class="header"><i class="fa fa-calendar"></i> Archive</li>
+        @foreach(DateTime published in Documents[Docs.BlogPosts]
+            .Select(x => x.Get<DateTime>(DocsKeys.Published))
+            .Select(x => new DateTime(x.Year, x.Month, 1))
+            .Distinct()
+            .OrderByDescending(x => x))
+        {
+            string link = published.ToString("yyyy/MM");
+            string selected = Model.String(Keys.RelativeFilePath).StartsWith($"{Context.String(DocsKeys.BlogPath)}/archive/{link}/") ? "selected" : null;
+            <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/archive/{link}")">@(published.ToString("MMMM, yyyy"))</a></li>
+        }
+    </ul>
+
     @if(Documents[Docs.BlogPosts].Any(x => x.ContainsKey(DocsKeys.Author)))
     {
-        <li class="header"><i class="fa fa-user"></i> Authors</li>    
-        @foreach(string author in Documents[Docs.BlogPosts]
-            .Select(x => x.String(DocsKeys.Author))
-            .Distinct()
-            .OrderBy(x => x))
+        <ul class="sidebar-menu">
+            <li class="header"><i class="fa fa-user"></i> Authors</li>
+            @foreach(string author in Documents[Docs.BlogPosts]
+                .Select(x => x.String(DocsKeys.Author))
+                .Distinct()
+                .OrderBy(x => x))
+            {
+                string link = author.Replace(" ", "-").Replace("'", string.Empty);
+                string selected = Model.String(Keys.RelativeFilePath).StartsWith($"{Context.String(DocsKeys.BlogPath)}/author/{link}/") ? "selected" : null;
+                <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/author/{link}")">@author</a></li>
+            }
+        </ul>
+    }
+
+    @if(Documents[Docs.BlogPosts].Any(x => x.ContainsKey(DocsKeys.Tags)))
+    {
+        var allTags = new List<string>();
+        @foreach(List<string> tagList in Documents[Docs.BlogPosts].Select(x => x.Get<List<string>>(DocsKeys.Tags)))
         {
-            string link = author.Replace(" ", "-").Replace("'", string.Empty);
-            string selected = Model.String(Keys.RelativeFilePath).StartsWith($"{Context.String(DocsKeys.BlogPath)}/author/{link}/") ? "selected" : null;
-            <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/author/{link}")">@author</a></li>
+            allTags.AddRange(tagList);
+        }
+
+        @Html.Raw(@"<ul class=""sidebar-menu sidebar-blog-tags"">")  @* This ul is closed outside section *@
+        <li class="header"><i class="fa fa-tags"></i> Tags</li>
+        @foreach(string tag in allTags.Distinct().OrderBy(x => x))
+        {
+            string link = tag.Replace(" ", "-").Replace("'", string.Empty);
+            string selected = Model.String(Keys.RelativeFilePath).StartsWith($"{Context.String(DocsKeys.BlogPath)}/tag/{link}/") ? "selected" : null;
+            <li class="@selected"><a href="@Context.GetLink($"/{Context.String(DocsKeys.BlogPath)}/tag/{link}")">@tag</a></li>
         }
     }
 }

--- a/themes/Docs/Samson/_BlogPost.cshtml
+++ b/themes/Docs/Samson/_BlogPost.cshtml
@@ -5,3 +5,5 @@
 @Html.Partial("_BlogPostDetails")
 
 @RenderBody()
+
+@Html.Partial("_BlogPostFooter")

--- a/themes/Docs/Samson/assets/css/theme/theme.less
+++ b/themes/Docs/Samson/assets/css/theme/theme.less
@@ -437,6 +437,17 @@ dl ol,
 	margin-bottom: 0;
 }
 
+ul.inline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  
+  li {
+    display: inline;
+    padding: 5px;
+  }
+}
+
 .paramref, .typeparamref {
 	font-style: italic;
 }

--- a/themes/Docs/Samson/assets/css/theme/theme.less
+++ b/themes/Docs/Samson/assets/css/theme/theme.less
@@ -310,6 +310,26 @@ h1 {
   {
     background-color: transparent;
   }
+
+  &.sidebar-blog-tags {
+    text-align: center;
+    font-size: @font-size-small;
+    margin-top: 15px;
+    line-height: 1.8;
+    border-top: solid 1px @gray-lighter;
+    padding-top: 6px;
+    
+    li:not(.header) {
+      display: inline;
+    }
+    
+    li a {
+      white-space: nowrap;
+      display: inline;
+      padding: 5px;
+      border-radius: 6px;
+    }
+  }
 } 
     
 .table-striped tr


### PR DESCRIPTION
Here is my proposal on how to render the blog tags in the Docs recipe.

This is what it looks like in the sidebar:
![image](https://user-images.githubusercontent.com/1295067/67631970-8ff0fd00-f89d-11e9-96e2-3557040c158d.png)

and in the blogpost:
![image](https://user-images.githubusercontent.com/1295067/67631979-a1d2a000-f89d-11e9-9021-a8ea32316af6.png)

The solution in _BlogLayout.cshtml is somewhat hackish to deal with the fact that the `ul` element is defined outside the SideBar section, with the benefit that each list in the sidebar now actually is rendered as a separate list. I opted to contain my changes to as few files as possible, please advice if I should rework it more.

ping @daveaglick 