### PR TITLE
SolidState theme close image path fix

### DIFF
--- a/themes/Blog/SolidState/assets/sass/components/layout/_menu.scss
+++ b/themes/Blog/SolidState/assets/sass/components/layout/_menu.scss
@@ -52,7 +52,7 @@
 		}
 
 		.close {
-			background-image: url('images/close.svg');
+			background-image: url('../css/images/close.svg');
 			background-position: 75% 25%;
 			background-repeat: no-repeat;
 			background-size: 2em 2em;

--- a/themes/Blog/SolidState/assets/sass/layout/_menu.scss
+++ b/themes/Blog/SolidState/assets/sass/layout/_menu.scss
@@ -52,7 +52,7 @@
 		}
 
 		.close {
-			background-image: url('images/close.svg');
+			background-image: url('../css/images/close.svg');
 			background-position: 75% 25%;
 			background-repeat: no-repeat;
 			background-size: 2em 2em;


### PR DESCRIPTION
Hi Dave,
started to use Wyam for my personal blog and I really love it so far.
I'm using the SolidState theme and noticed that the close image didn't appear in the dialog. The close.svg ends up in output/assets/css/images so I changed the path.
This is really a minor issue - thank you for the great work!