### PR TITLE
Sitemap inclusion metadata

### DIFF
--- a/src/Statiq.Web/Pipelines/Sitemap.cs
+++ b/src/Statiq.Web/Pipelines/Sitemap.cs
@@ -18,13 +18,21 @@ namespace Statiq.Web.Pipelines
                 {
                     new ConcatDocuments(nameof(Content))
                     {
-                        new FilterDocuments(Config.FromDocument(WebKeys.ShouldOutput, true))
+                        new FilterDocuments(
+                            Config.FromDocument(WebKeys.ShouldOutput, true).CombineWith(
+                            Config.FromDocument(WebKeys.IncludeInSitemap, true)))
                     },
                     new ConcatDocuments(nameof(Data))
                     {
-                        new FilterDocuments(Config.FromDocument<bool>(WebKeys.ShouldOutput))
+                        new FilterDocuments(
+                            Config.FromDocument(WebKeys.ShouldOutput, true).CombineWith(
+                            Config.FromDocument(WebKeys.IncludeInSitemap, true)))
                     },
-                    new ConcatDocuments(nameof(Archives)),
+                    new ConcatDocuments(nameof(Archives))
+                    {
+                        new FilterDocuments(
+                            Config.FromDocument(WebKeys.IncludeInSitemap, true))
+                    },
                     new FlattenTree(),
                     new FilterDocuments(Config.FromDocument(doc => !doc.GetBool(Keys.TreePlaceholder))),
                     new GenerateSitemap()

--- a/src/Statiq.Web/WebKeys.cs
+++ b/src/Statiq.Web/WebKeys.cs
@@ -38,6 +38,8 @@ namespace Statiq.Web
         /// </summary>
         public const string GenerateSitemap = nameof(GenerateSitemap);
 
+        public const string IncludeInSitemap = nameof(IncludeInSitemap);
+
         public const string MirrorResources = nameof(MirrorResources);
 
         /// <summary>

--- a/tests/Statiq.Web.Tests/Pipelines/SitemapFixture.cs
+++ b/tests/Statiq.Web.Tests/Pipelines/SitemapFixture.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Shouldly;
+using Statiq.App;
+using Statiq.Common;
+using Statiq.Testing;
+using Statiq.Web.Pipelines;
+
+namespace Statiq.Web.Tests.Pipelines
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class SitemapFixture
+    {
+        public class ExecuteTests : DataFixture
+        {
+            [Test]
+            public async Task IncludeInSitemapByDefault()
+            {
+                // Given
+                Bootstrapper bootstrapper = Bootstrapper
+                    .Factory
+                    .CreateWeb(Array.Empty<string>());
+
+                TestFileProvider fileProvider = new TestFileProvider
+                {
+                    {
+                        "/input/foo.html",
+                        ContentFile
+                    }
+                };
+
+                // When
+                BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+                // Then
+                result.ExitCode.ShouldBe((int)ExitCode.Normal);
+                IDocument document = result.Outputs[nameof(Sitemap)][Phase.Output].ShouldHaveSingleItem();
+                string sitemapContent = await document.GetContentStringAsync();
+                sitemapContent.ShouldContain("<loc>/foo</loc>");
+            }
+
+            [Test]
+            public async Task IncludeInSitemapWhenSpecified()
+            {
+                // Given
+                Bootstrapper bootstrapper = Bootstrapper
+                    .Factory
+                    .CreateWeb(Array.Empty<string>())
+                    .AddSetting(WebKeys.GenerateSitemap, true);
+
+                TestFileProvider fileProvider = new TestFileProvider
+                {
+                    {
+                        "/input/foo.html",
+                        @"IncludeInSitemap: true
+---" + ContentFile
+                    }
+                };
+
+                // When
+                BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+                // Then
+                result.ExitCode.ShouldBe((int)ExitCode.Normal);
+                IDocument document = result.Outputs[nameof(Sitemap)][Phase.Output].ShouldHaveSingleItem();
+                string sitemapContent = await document.GetContentStringAsync();
+                sitemapContent.ShouldContain("<loc>/foo</loc>");
+            }
+
+            [Test]
+            public async Task ExcludeFromSitemapWhenSpecified()
+            {
+                // Given
+                Bootstrapper bootstrapper = Bootstrapper
+                    .Factory
+                    .CreateWeb(Array.Empty<string>())
+                    .AddSetting(WebKeys.GenerateSitemap, true);
+
+                TestFileProvider fileProvider = new TestFileProvider
+                {
+                    {
+                        "/input/foo.html",
+                        @"IncludeInSitemap: false
+---" + ContentFile
+                    }
+                };
+
+                // When
+                BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+                // Then
+                result.ExitCode.ShouldBe((int)ExitCode.Normal);
+                IDocument document = result.Outputs[nameof(Sitemap)][Phase.Output].ShouldHaveSingleItem();
+                string sitemapContent = await document.GetContentStringAsync();
+                sitemapContent.ShouldNotContain("<loc>/foo</loc>");
+            }
+        }
+
+        public const string ContentFile = @"
+<html>
+  <head>
+  </head>
+  <body>
+  </body>
+</html>";
+    }
+}


### PR DESCRIPTION
Adds a setting to specify whether documents should be included in the sitemap. This enables certain documents to be excluded from the sitemap, such as data files or a 404 page.