### PR TITLE
Close <ItemGroup> tag in Statiq.Web.props

### DIFF
--- a/src/Statiq.Web/Statiq.Web.props
+++ b/src/Statiq.Web/Statiq.Web.props
@@ -3,6 +3,7 @@
     <Compile Remove="theme\**" />
     <Compile Remove="extensions\**" />
     <Compile Remove="archetypes\**" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="theme\**">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>


### PR DESCRIPTION
Seems to be causing the following error when building:

> error MSB4024: The imported project file "C:\Users\a\.nuget\packages\statiq.web\1.0.0-alpha.17\build\netcoreapp3.1\Statiq.Web.props" could not be loaded. The 'ItemGroup' start tag on line 2 position 4 does not match the end tag of 'Project'. Line 17, position 3.