### PR TITLE
Add Statiq.Web .NET CLI template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,23 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: Statiq.Web
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Get Source
         uses: actions/checkout@v2
+        with:
+          path: Statiq.Web
+
+      - name: Checkout Statiq.Framework
+        uses: actions/checkout@v2
+        with:
+          repository: statiqdev/Statiq.Framework
+          path: Statiq.Framework
 
       - name: Install .NET Core SDK
         uses: actions/setup-dotnet@v1

--- a/Statiq.Web.sln
+++ b/Statiq.Web.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E6164A48
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.Web.Build", "build\Statiq.Web.Build\Statiq.Web.Build.csproj", "{0A3CAA9E-68D4-411F-97A2-7266C949D9BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.Web.Templates", "src\Statiq.Web.Templates\Statiq.Web.Templates.csproj", "{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,18 @@ Global
 		{0A3CAA9E-68D4-411F-97A2-7266C949D9BA}.Release|x64.Build.0 = Release|Any CPU
 		{0A3CAA9E-68D4-411F-97A2-7266C949D9BA}.Release|x86.ActiveCfg = Release|Any CPU
 		{0A3CAA9E-68D4-411F-97A2-7266C949D9BA}.Release|x86.Build.0 = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|x64.Build.0 = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,6 +173,7 @@ Global
 		{7FDA6CBA-FCDA-42B9-935B-5F6C01DE4276} = {E58D9954-583A-493C-B607-4AD2C4AED9A5}
 		{9CE227F6-A4FF-44CC-98CC-DB8C087CF4C3} = {E58D9954-583A-493C-B607-4AD2C4AED9A5}
 		{0A3CAA9E-68D4-411F-97A2-7266C949D9BA} = {E6164A48-43FF-4138-B7F6-82A1388C8CF6}
+		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C} = {E58D9954-583A-493C-B607-4AD2C4AED9A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EFD0E489-F8EE-4626-91C8-92A8F7092907}

--- a/build/Statiq.Web.Build/Program.cs
+++ b/build/Statiq.Web.Build/Program.cs
@@ -14,8 +14,8 @@ namespace Statiq.Web.Build
         private static readonly NormalizedPath ArtifactsFolder = "artifacts";
         private static readonly string GitHubOwner = "statiqdev";
         private static readonly string GitHubName = "Statiq.Web";
-
         private static readonly string BuildServer = nameof(BuildServer);
+        private static readonly string ProjectPattern = "src/**/{!templates,}/**/*.csproj";
 
         public static async Task<int> Main(string[] args) => await Bootstrapper
             .Factory
@@ -39,7 +39,7 @@ namespace Statiq.Web.Build
 
                 ProcessModules = new ModuleList
                 {
-                    new ReadFiles("src/**/*.csproj"),
+                    new ReadFiles(ProjectPattern),
                     new StartProcess("dotnet")
                         .WithArgument("build")
                         .WithArgument(Config.FromContext(context =>
@@ -82,7 +82,7 @@ namespace Statiq.Web.Build
                 ProcessModules = new ModuleList
                 {
                     new ThrowExceptionIf(Config.ContainsSettings("DAVIDGLICK_CERTPASS").IsFalse(), "DAVIDGLICK_CERTPASS setting missing"),
-                    new ReadFiles("src/**/*.csproj"),
+                    new ReadFiles(ProjectPattern),
                     new StartProcess("dotnet")
                         .WithArgument("pack")
                         .WithArgument("--no-build")

--- a/src/Statiq.Web.Templates/Statiq.Web.Templates.csproj
+++ b/src/Statiq.Web.Templates/Statiq.Web.Templates.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageId>Statiq.Web.Templates</PackageId>
+    <Title>Statiq Web Templates</Title>
+    <Authors>Dave Glick</Authors>
+    <Description>Templates to use when creating a Statiq Web application, Statiq Web is a flexible static site generator.</Description>
+    <PackageTags>dotnet-new;templates;Statiq;Static;StaticContent;StaticSite;Blog;BlogEngine </PackageTags>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <ContentTargetFolders>content</ContentTargetFolders>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;templates\**\.vs\**" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <Target Name="VersionBuild" BeforeTargets="PrepareForBuild">
+   <XmlPoke XmlInputPath="templates\statiq-web\StatiqWeb\StatiqWeb.csproj" Query="Project/ItemGroup/PackageReference/@Version" Value="$(Version)" />
+  </Target>
+</Project>

--- a/src/Statiq.Web.Templates/templates/statiq-web/.template.config/template.json
+++ b/src/Statiq.Web.Templates/templates/statiq-web/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Dave Glick",
+  "classifications": [ "Web", "Statiq" ],
+  "identity": "Statiq.Web.Templates.ConsoleTemplate.CSharp",
+  "name": "Statiq Web Console Application",
+  "shortName": "statiq-web",
+  "sourceName": "StatiqWeb",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  }
+}

--- a/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/Program.cs
+++ b/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/Program.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Statiq.App;
+using Statiq.Web;
+
+namespace StatiqWeb
+{
+    public class Program
+    {
+        public static async Task<int> Main(string[] args) =>
+            await Bootstrapper
+                .Factory
+                .CreateWeb(args)
+                .RunAsync();
+    }
+}

--- a/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/StatiqWeb.csproj
+++ b/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/StatiqWeb.csproj
@@ -8,6 +8,6 @@
     <Folder Include="output\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.3" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.4" />
   </ItemGroup>
 </Project>

--- a/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/StatiqWeb.csproj
+++ b/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/StatiqWeb.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="input\" />
+    <Folder Include="output\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.3" />
+  </ItemGroup>
+</Project>

--- a/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/input/index.md
+++ b/src/Statiq.Web.Templates/templates/statiq-web/StatiqWeb/input/index.md
@@ -1,0 +1,5 @@
+Title: My First Statiq page
+---
+# Hello World!
+
+Hello from my first Statiq page.


### PR DESCRIPTION
This adds a .NET CLI template, simplifies getting started with Statiq.Web

Currently just a project template, but nuget could contain more in the future.

Usage
```bash
dotnet new statiq-web -n MyWeb
```

Result
```
└───MyWeb
    │   MyWeb.csproj
    │   Program.cs
    │
    └───input
            index.md
```

When on nuget it would just be installed 
```
dotnet new -i Statiq.Web.Templates
```

To test pr
```bash
dotnet pack .\src\Statiq.Web.Templates\Statiq.Web.Templates.csproj
dotnet new -i .\src\Statiq.Web.Templates\bin\Debug\Statiq.Web.Templates.1.0.0-beta.3.nupkg
```