### PR TITLE
Fixed bug that prevented processing of non-ascii symbols

### DIFF
--- a/src/Statiq.Web.Hosting/Middleware/DefaultExtensionsMiddleware.cs
+++ b/src/Statiq.Web.Hosting/Middleware/DefaultExtensionsMiddleware.cs
@@ -37,7 +37,7 @@ namespace Statiq.Web.Hosting.Middleware
                 // Check if there's a file with a matched extension, and rewrite the request if found
                 foreach (string extension in _extensions)
                 {
-                    string filePath = context.Request.Path.ToString() + extension;
+                    string filePath = context.Request.Path.Value + extension;
                     IFileInfo fileInfo = _fileProvider.GetFileInfo(filePath);
                     if (fileInfo?.Exists == true)
                     {


### PR DESCRIPTION
context.Request.Path.ToString() was leaving url encoded symbols as is. It means when further code tried to check if file exists on disc, result was always false in case of non-latin filenames.

I am not sure if any additional code is neccessary here. For some reason, I can't open and run Statiq solution on my PC properly. 