### PR TITLE
Prevent Data documents being included by default in Sitemaps

### DIFF
--- a/src/Statiq.Web/Pipelines/Sitemap.cs
+++ b/src/Statiq.Web/Pipelines/Sitemap.cs
@@ -26,7 +26,7 @@ namespace Statiq.Web.Pipelines
                     {
                         new FilterDocuments(
                             Config.FromDocument(WebKeys.ShouldOutput, true).CombineWith(
-                            Config.FromDocument(WebKeys.IncludeInSitemap, true)))
+                            Config.FromDocument(WebKeys.IncludeInSitemap, false)))
                     },
                     new ConcatDocuments(nameof(Archives))
                     {


### PR DESCRIPTION
I know this might seem a little extreme and maybe I'm missing something but it doesn't make sense to me why [data files](https://www.statiq.dev/web/content-and-data/data) would be in a sitemap.

The core thing here is that sitemaps help search engines and crawlers to find web pages. While you might access the data via JS, search engines don't really care about. For example, the [statiq.dev site itself exposes some YAML files via the sitemap file](https://www.statiq.dev/sitemap.xml) and they aren't even accessible. (eg. https://www.statiq.dev/news/topics/release.yml )

I first discovered this by accident when a tool I use reported that there were YAML files linked to on my site. I thought I broke something but the default behaviour seemed to include the files. While I disabled them individually in my case, it only dawned on me now that it didn't make sense to include them in the first place.

----

I could have it that it stays but the defaults are `false` just in case someone _really_ wants it in their sitemap but I really don't see the point. Crawlers aren't exactly wanting to stumble across a YAML file.