### PR TITLE
Support modifying Feed paths

### DIFF
--- a/src/Statiq.Web/Pipelines/Feeds.cs
+++ b/src/Statiq.Web/Pipelines/Feeds.cs
@@ -61,9 +61,9 @@ namespace Statiq.Web.Pipelines
                         // Generate the feed(s)
                         GenerateFeeds generateFeeds = new GenerateFeeds()
                             .MaximumItems(feedDoc.GetInt(WebKeys.FeedSize))
-                            .WithRssPath(feedDoc.GetBool(WebKeys.FeedRss, false) ? feedDoc.Destination.ChangeExtension("rss") : null)
-                            .WithAtomPath(feedDoc.GetBool(WebKeys.FeedAtom, false) ? feedDoc.Destination.ChangeExtension("atom") : null)
-                            .WithRdfPath(feedDoc.GetBool(WebKeys.FeedRdf, false) ? feedDoc.Destination.ChangeExtension("rdf") : null)
+                            .WithRssPath(TryGetFeedPath(feedDoc, WebKeys.FeedRss, "rss", out NormalizedPath feedPath) ? feedPath : null)
+                            .WithAtomPath(TryGetFeedPath(feedDoc, WebKeys.FeedAtom, "atom", out feedPath) ? feedPath : null)
+                            .WithRdfPath(TryGetFeedPath(feedDoc, WebKeys.FeedRdf, "rdf", out feedPath) ? feedPath : null)
                             .WithFeedId(feedDoc.GetString(WebKeys.FeedId))
                             .WithFeedTitle(feedDoc.GetString(WebKeys.FeedTitle))
                             .WithFeedDescription(feedDoc.GetString(WebKeys.FeedDescription))
@@ -139,5 +139,19 @@ namespace Statiq.Web.Pipelines
 
         public static bool IsFeed(IDocument document) =>
             document.ContainsKey(WebKeys.FeedRss) || document.ContainsKey(WebKeys.FeedAtom) || document.ContainsKey(WebKeys.FeedRdf);
+
+        private static bool TryGetFeedPath(IDocument feedDoc, string key, string defaultExtension, out NormalizedPath path)
+        {
+            if (feedDoc.ContainsKey(key))
+            {
+                path = feedDoc.Destination.ChangeExtension(defaultExtension);
+                if ((feedDoc.TryGetValue(key, out bool includeFeedType) && includeFeedType) || feedDoc.TryGetValue(key, out path))
+                {
+                    return true;
+                }
+            }
+            path = default;
+            return false;
+        }
     }
 }

--- a/tests/Statiq.Web.Tests/Pipelines/FeedsFixture.cs
+++ b/tests/Statiq.Web.Tests/Pipelines/FeedsFixture.cs
@@ -63,6 +63,29 @@ FeedRss: true"
                 result.ExitCode.ShouldBe((int)ExitCode.Normal);
                 result.Outputs[nameof(Web.Pipelines.Feeds)][Phase.Process].ShouldBeEmpty();
             }
+
+            [Test]
+            public async Task ToggleFeedWithPath()
+            {
+                // Given
+                Bootstrapper bootstrapper = Bootstrapper.Factory.CreateWeb(Array.Empty<string>());
+                TestFileProvider fileProvider = new TestFileProvider
+                {
+                    { "/input/foo.md", "Hi!" },
+                    {
+                        "/input/feed.yml",
+                        "FeedRss: rss/custom-feed.xml"
+                    }
+                };
+
+                // When
+                BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+                // Then
+                result.ExitCode.ShouldBe((int)ExitCode.Normal);
+                IDocument document = result.Outputs[nameof(Web.Pipelines.Feeds)][Phase.Process].ShouldHaveSingleItem();
+                document.Destination.ShouldBe("rss/custom-feed.xml");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #960 

Using `FeedRss`, `FeedAtom` and `FeedRdf` keys, you can specify `true`, `false` or a string path. Specifying true/false will behave as before. When you specify a path, this will be the destination path used for the feed itself.