### PR TITLE
Also generates an excerpt for cshtml sources

### DIFF
--- a/src/Statiq.Web/Pipelines/Content.cs
+++ b/src/Statiq.Web/Pipelines/Content.cs
@@ -27,7 +27,8 @@ namespace Statiq.Web.Pipelines
                         new OptimizeFileName()
                     },
                     new RenderContentProcessTemplates(templates),
-                    new ExecuteIf(Config.FromDocument(doc => doc.MediaTypeEquals(MediaTypes.Html)))
+                    new ExecuteIf(Config.FromDocument(
+                        doc => doc.MediaTypeEquals(MediaTypes.Html) || doc.MediaTypeEquals(MediaTypes.Razor)))
                     {
                         // Excerpts and headings only work for HTML content
                         new GenerateExcerpt(),

--- a/tests/Statiq.Web.Tests/Pipelines/ContentFixture.cs
+++ b/tests/Statiq.Web.Tests/Pipelines/ContentFixture.cs
@@ -753,6 +753,84 @@ End"
             }
         }
 
+        [Test]
+        public async Task GenerateExcerptForHtml()
+        {
+            // Given
+            Bootstrapper bootstrapper = Bootstrapper.Factory.CreateWeb(Array.Empty<string>());
+            TestFileProvider fileProvider = new TestFileProvider
+            {
+                {
+                    "/input/foo.html",
+                    "<p>Excerpt</p>"
+                }
+            };
+
+            // When
+            BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+            // Then
+            result.ExitCode.ShouldBe((int)ExitCode.Normal);
+            IDocument document = result.Outputs[nameof(Content)][Phase.Process].ShouldHaveSingleItem();
+            document.Get<string>(Keys.Excerpt).ShouldBe("<p>Excerpt</p>");
+        }
+
+        [Test]
+        public async Task GenerateExcerptForMarkdown()
+        {
+            // Given
+            Bootstrapper bootstrapper = Bootstrapper.Factory.CreateWeb(Array.Empty<string>());
+            TestFileProvider fileProvider = new TestFileProvider
+            {
+                {
+                    "/input/foo.md",
+                    "Excerpt"
+                }
+            };
+
+            // When
+            BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+            // Then
+            result.ExitCode.ShouldBe((int)ExitCode.Normal);
+            IDocument document = result.Outputs[nameof(Content)][Phase.Process].ShouldHaveSingleItem();
+            document.Get<string>(Keys.Excerpt).ShouldBe("<p>Excerpt</p>");
+        }
+
+        [Test]
+        public async Task GenerateExcerptForRazor()
+        {
+            // Given
+            Bootstrapper bootstrapper = Bootstrapper.Factory.CreateWeb(Array.Empty<string>());
+            TestFileProvider fileProvider = new TestFileProvider
+            {
+                {
+                    "/input/Test.cshtml",
+                    "<p>Excerpt</p>"
+                },
+                {
+                    "/input/_Layout.cshtml",
+                    @"<html><head></head><body>
+    @RenderBody()
+</body></html>"
+                },
+                {
+                    "/input/_ViewStart.cshtml",
+                    @"@{
+    Layout = ""_Layout"";
+}"
+                },
+            };
+
+            // When
+            BootstrapperTestResult result = await bootstrapper.RunTestAsync(fileProvider);
+
+            // Then
+            result.ExitCode.ShouldBe((int)ExitCode.Normal);
+            IDocument document = result.Outputs[nameof(Content)][Phase.Process].ShouldHaveSingleItem();
+            document.Get<string>(Keys.Excerpt).ShouldBe("<p>Excerpt</p>");
+        }
+
         public const string GatherHeadingsFile = @"
 <html>
   <head>


### PR DESCRIPTION
Because `cshtml` is also translated to html, makes sense to be able to generate excerpts from `cshtml` files as well. Added some tests to confirm that it works.