### PR TITLE
Fix Lunr Search Resource Paths

### DIFF
--- a/src/Statiq.Web/Pipelines/SearchIndex.cs
+++ b/src/Statiq.Web/Pipelines/SearchIndex.cs
@@ -46,7 +46,9 @@ namespace Statiq.Web.Pipelines
 
                         // Create the module
                         GenerateLunrIndex generateLunrIndex = new GenerateLunrIndex()
-                            .WithIndexPath(ctx.GetPath(WebKeys.SearchScriptPath))
+                            .WithScriptPath(ctx.GetPath(WebKeys.SearchScriptPath, NormalizedPath.Null))
+                            .WithIndexPath(ctx.GetPath(WebKeys.SearchIndexPath, NormalizedPath.Null))
+                            .WithResultsPath(ctx.GetPath(WebKeys.SearchResultsPath, NormalizedPath.Null))
                             .ZipIndexFile(ctx.GetBool(WebKeys.ZipSearchIndexFile, true))
                             .ZipResultsFile(ctx.GetBool(WebKeys.ZipSearchResultsFile, true))
                             .IncludeHostInLinks(ctx.GetBool(WebKeys.SearchIncludeHost))

--- a/src/Statiq.Web/WebKeys.cs
+++ b/src/Statiq.Web/WebKeys.cs
@@ -60,12 +60,12 @@ namespace Statiq.Web
         /// The destination path of the client-side Lunr search file ("search.js" by default).
         /// </summary>
         public const string SearchScriptPath = nameof(SearchScriptPath);
-        
+
         /// <summary>
         /// The destination path of the search index file ("search.index.json" or "search.index.json.gz" by default).
         /// </summary>
         public const string SearchIndexPath = nameof(SearchIndexPath);
-        
+
         /// <summary>
         /// The destination path of the search results file ("search.results.json" or "search.results.json.gz" by default).
         /// </summary>

--- a/src/Statiq.Web/WebKeys.cs
+++ b/src/Statiq.Web/WebKeys.cs
@@ -60,6 +60,16 @@ namespace Statiq.Web
         /// The destination path of the client-side Lunr search file ("search.js" by default).
         /// </summary>
         public const string SearchScriptPath = nameof(SearchScriptPath);
+        
+        /// <summary>
+        /// The destination path of the search index file ("search.index.json" or "search.index.json.gz" by default).
+        /// </summary>
+        public const string SearchIndexPath = nameof(SearchIndexPath);
+        
+        /// <summary>
+        /// The destination path of the search results file ("search.results.json" or "search.results.json.gz" by default).
+        /// </summary>
+        public const string SearchResultsPath = nameof(SearchResultsPath);
 
         /// <summary>
         /// Indicates whether the search index file should be gzipped (the default is <c>true</c>).


### PR DESCRIPTION
At present, setting the `SearchScriptPath` key does not change the script path as expected, but changes the index path. This patch fixes the `SearchScriptPath` to work as expected, as well as adding keys to set the path for the index and results file.

Note that as this changes the behaviour of the existing `SearchScriptPath` key, this should be considered a breaking change. However, dealing with this is simply a matter of changing `SearchScriptPath` to `SearchIndexPath` in any configuration.

This also addresses a "feature" in Azure Static Apps, where files ending in `.gz` are served with compression headers, causing browsers to automatically decompress the file before passing the result to javascript. This causes the search script to fail, as it is expecting compressed data.