### PR TITLE
Updated to .Net 8

### DIFF
--- a/Statiq.Web.sln
+++ b/Statiq.Web.sln
@@ -1,7 +1,6 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statiq.Web", "src\Statiq.Web\Statiq.Web.csproj", "{9AD88CBA-5E7F-4082-AC1A-5D0DD2FEE46B}"
 EndProject
@@ -27,7 +26,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statiq.Web.Templates", "src
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{34DEAA8E-925D-4894-8050-37F16AE3718E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.Web.Examples", "examples\Statiq.Web.Examples\Statiq.Web.Examples.csproj", "{E018A43C-D969-4FFD-A171-A7C4C96CEE40}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statiq.Web.Examples", "examples\Statiq.Web.Examples\Statiq.Web.Examples.csproj", "{E018A43C-D969-4FFD-A171-A7C4C96CEE40}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{BFA13976-FBC4-49C7-BBBD-C773863EED26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildalyzer.Workspaces", "..\Buildalyzer\src\Buildalyzer.Workspaces\Buildalyzer.Workspaces.csproj", "{C1439BB2-C554-4337-9D25-6AD69B9F2506}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildalyzer", "..\Buildalyzer\src\Buildalyzer\Buildalyzer.csproj", "{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildalyzer.Logger", "..\Buildalyzer\src\Buildalyzer.Logger\Buildalyzer.Logger.csproj", "{49A9FFC9-5F10-4039-96A4-80B76A1735C3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -159,6 +166,42 @@ Global
 		{E018A43C-D969-4FFD-A171-A7C4C96CEE40}.Release|x64.Build.0 = Release|Any CPU
 		{E018A43C-D969-4FFD-A171-A7C4C96CEE40}.Release|x86.ActiveCfg = Release|Any CPU
 		{E018A43C-D969-4FFD-A171-A7C4C96CEE40}.Release|x86.Build.0 = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Debug|x86.Build.0 = Debug|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|x64.Build.0 = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506}.Release|x86.Build.0 = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|x64.Build.0 = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Debug|x86.Build.0 = Debug|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|x64.ActiveCfg = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|x64.Build.0 = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|x86.ActiveCfg = Release|Any CPU
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7}.Release|x86.Build.0 = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Debug|x86.Build.0 = Debug|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|x64.Build.0 = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,6 +217,9 @@ Global
 		{9CE227F6-A4FF-44CC-98CC-DB8C087CF4C3} = {E58D9954-583A-493C-B607-4AD2C4AED9A5}
 		{EB5E8E9B-8480-4E5D-B7D1-DAAC7C348D7C} = {E58D9954-583A-493C-B607-4AD2C4AED9A5}
 		{E018A43C-D969-4FFD-A171-A7C4C96CEE40} = {34DEAA8E-925D-4894-8050-37F16AE3718E}
+		{C1439BB2-C554-4337-9D25-6AD69B9F2506} = {BFA13976-FBC4-49C7-BBBD-C773863EED26}
+		{1A00711E-23AA-46FE-BD67-C20BBD43FEC7} = {BFA13976-FBC4-49C7-BBBD-C773863EED26}
+		{49A9FFC9-5F10-4039-96A4-80B76A1735C3} = {BFA13976-FBC4-49C7-BBBD-C773863EED26}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EFD0E489-F8EE-4626-91C8-92A8F7092907}

--- a/examples/Statiq.Web.Examples/Statiq.Web.Examples.csproj
+++ b/examples/Statiq.Web.Examples/Statiq.Web.Examples.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="output\**" />
     <EmbeddedResource Remove="output\**" />
     <None Remove="output\**" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Statiq.Web\Statiq.Web.csproj" />
+
   </ItemGroup>
-  
 </Project>

--- a/src/Statiq.Web.Aws/Statiq.Web.Aws.csproj
+++ b/src/Statiq.Web.Aws/Statiq.Web.Aws.csproj
@@ -2,11 +2,17 @@
   <PropertyGroup>
     <Description>Statiq is a configurable static content generation framework. This library provides support for interacting with AWS.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine AmazonWebServices AWS</PackageTags>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -19,5 +25,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
+++ b/src/Statiq.Web.Azure/Statiq.Web.Azure.csproj
@@ -2,12 +2,18 @@
   <PropertyGroup>
     <Description>Statiq is a configurable static content generation framework. This library provides support for interacting with Azure.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Azure AppService</PackageTags>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
     <PackageReference Include="Polly" Version="7.1.1" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -20,5 +26,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/src/Statiq.Web.GitHub/Statiq.Web.GitHub.csproj
+++ b/src/Statiq.Web.GitHub/Statiq.Web.GitHub.csproj
@@ -2,8 +2,14 @@
   <PropertyGroup>
     <Description>GitHub modules for Statiq including GitHub Pages deployment support.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine GitHub GitHubPages</PackageTags>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -16,10 +22,8 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.46.0" />
     <PackageReference Include="Polly" Version="7.1.1" />
   </ItemGroup>
-
 </Project>

--- a/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
+++ b/src/Statiq.Web.Hosting/Statiq.Web.Hosting.csproj
@@ -3,6 +3,7 @@
     <Description>Statiq is a configurable static content generation framework. This library contains a server for use with static sites.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Hosting WebHost</PackageTags>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="LiveReload\livereload.js" />
@@ -23,7 +24,6 @@
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -36,5 +36,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
+++ b/src/Statiq.Web.Netlify/Statiq.Web.Netlify.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Statiq is a configurable static content generation framework. This library provides support for interacting with Netlify.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Netlify</PackageTags>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NetlifySharp" Version="1.1.0" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -21,5 +25,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/src/Statiq.Web.Templates/Statiq.Web.Templates.csproj
+++ b/src/Statiq.Web.Templates/Statiq.Web.Templates.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>Statiq.Web.Templates</PackageId>
@@ -7,20 +6,18 @@
     <Authors>Dave Glick</Authors>
     <Description>Templates to use when creating a Statiq Web application, Statiq Web is a flexible static site generator.</Description>
     <PackageTags>dotnet-new;templates;Statiq;Static;StaticContent;StaticSite;Blog;BlogEngine </PackageTags>
-
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;templates\**\.vs\**" />
     <Compile Remove="**\*" />
   </ItemGroup>
-
   <Target Name="VersionBuild" BeforeTargets="PrepareForBuild">
-   <XmlPoke XmlInputPath="templates\statiq-web\Statiq.Web.Template.csproj" Query="Project/ItemGroup/PackageReference/@Version" Value="$(Version)" />
+    <XmlPoke XmlInputPath="templates\statiq-web\Statiq.Web.Template.csproj" Query="Project/ItemGroup/PackageReference/@Version" Value="$(Version)" />
   </Target>
 </Project>

--- a/src/Statiq.Web/Statiq.Web.csproj
+++ b/src/Statiq.Web/Statiq.Web.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Statiq Web is a flexible static site generator.</Description>
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062;CA1021;CA1710</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062;CA1021;CA1710</WarningsNotAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="Statiq.Web.targets" Pack="true" PackagePath="build\$(TargetFramework)\" />
     <None Include="Statiq.Web.targets" Pack="true" PackagePath="buildTransitive\$(TargetFramework)\" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Buildalyzer.Workspaces" Version="4.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <ProjectReference Include="..\..\..\Buildalyzer\src\Buildalyzer.Workspaces\Buildalyzer.Workspaces.csproj" />
     <ProjectReference Include="..\Statiq.Web.Aws\Statiq.Web.Aws.csproj" />
     <ProjectReference Include="..\Statiq.Web.Azure\Statiq.Web.Azure.csproj" />
     <ProjectReference Include="..\Statiq.Web.GitHub\Statiq.Web.GitHub.csproj" />
     <ProjectReference Include="..\Statiq.Web.Hosting\Statiq.Web.Hosting.csproj" />
     <ProjectReference Include="..\Statiq.Web.Netlify\Statiq.Web.Netlify.csproj" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -56,5 +56,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/tests/Statiq.Web.Hosting.Tests/Statiq.Web.Hosting.Tests.csproj
+++ b/tests/Statiq.Web.Hosting.Tests/Statiq.Web.Hosting.Tests.csproj
@@ -1,6 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724;CA1062</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="index.html" />
@@ -15,7 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0" />  <!-- Required for GenerateEmbeddedFilesManifest task -->
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0" />
+    <!-- Required for GenerateEmbeddedFilesManifest task -->
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\BasicHtmlDocument.html" />
@@ -23,7 +31,6 @@
     <EmbeddedResource Include="wwwroot\BasicHtmlDocumentNoHtml.html" />
     <EmbeddedResource Include="wwwroot\NonHtmlDocument.css" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -37,5 +44,4 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
 </Project>

--- a/tests/Statiq.Web.Tests/Statiq.Web.Tests.csproj
+++ b/tests/Statiq.Web.Tests/Statiq.Web.Tests.csproj
@@ -1,11 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Statiq.Web\Statiq.Web.csproj" />
   </ItemGroup>
-
   <Choose>
     <When Condition=" '$(StatiqFrameworkVersion)' == ''">
       <ItemGroup>
@@ -19,9 +18,10 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
-
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <DefineConstants>Is_Windows</DefineConstants>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This Pull Request is updating all projects to target .net 8

However, it's dependant on https://github.com/statiqdev/Statiq.Framework/pull/278 and https://github.com/phmonte/Buildalyzer to release a new version (due to issues in resolving legacy dependencies).

Buildalyzer has already changes merged, but not yet released a version with a fix. For performing the update, I used a local reference - once the version is released I'll reverse that change, until then it's just a Draft Pull Request.

In addition Microsoft.Azure.Search had been deprecated (used bei Statiq.Web.Azure) and should be replaced by Azure.Search.Documents. Will migrate this, but did not yet have the chance to setup a test instance.